### PR TITLE
Update WhisperFactory.cs

### DIFF
--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -27,13 +27,13 @@ public sealed class WhisperFactory : IDisposable
 
     private WhisperFactory(IWhisperProcessorModelLoader loader, bool delayInit, string? libraryPath = default, bool bypassLoading = false)
     {
+        WhisperFactory.libraryPath = libraryPath;
+        WhisperFactory.bypassLoading = bypassLoading;
+        
         if (!libraryLoaded.Value.IsSuccess)
         {
             throw new Exception($"Failed to load native whisper library. Error: {libraryLoaded.Value.ErrorMessage}");
         }
-
-        WhisperFactory.libraryPath = libraryPath;
-        WhisperFactory.bypassLoading = bypassLoading;
 
         this.loader = loader;
         if (!delayInit)


### PR DESCRIPTION
Since I needed a custom dll path, I noticed this isn't passed so far and the default path was always used. Positioning the if query after the variable declarations solved the problem for me. I think the if (!libraryLoaded.value.isSuccess) query before WhisperFactory.librayPath = libraryPath; was a bug.