### PR TITLE
bugfix for max file size error

### DIFF
--- a/Whisper.net/Ggml/WhisperGgmlDownloader.cs
+++ b/Whisper.net/Ggml/WhisperGgmlDownloader.cs
@@ -24,7 +24,7 @@ public static class WhisperGgmlDownloader
         };
 
         var request = new HttpRequestMessage(HttpMethod.Get, url);
-        var response = await httpClient.Value.SendAsync(request, cancellationToken);
+        var response = await httpClient.Value.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
 
 #if IOS || MACCATALYST || TVOS || ANDROID || MACOS


### PR DESCRIPTION
bugfix for error `System.Net.Http.HttpRequestException: Cannot write more bytes to the buffer than the configured maximum buffer size: 2147483647` when trying to download the large model file. Solution is from [here](https://stackoverflow.com/questions/18720435/httpclient-buffer-size-limit-exceeded)