### PR TITLE
Bump whisper.cpp and address breaking changes

### DIFF
--- a/Whisper.net/Internals/Native/Data.cs
+++ b/Whisper.net/Internals/Native/Data.cs
@@ -97,8 +97,15 @@ internal struct WhisperFullParams
     // speed-up the audio by 2x using Phase Vocoder
     public byte SpeedUp2x;
 
+    // enable debug_mode provides extra info (eg. Dump log_mel)
+    public byte DebugMode;
+
     // overwrite the audio context size (0 = use default)
     public int AudioContextSize;
+
+    // [EXPERIMENTAL] [TDRZ] tinydiarize
+    // enable tinydiarize speaker turn detection
+    public byte TinyDiarizeSpeakerTurnDirection;
 
     public IntPtr InitialPrompt;
 

--- a/Whisper.net/Internals/Native/NativeMethods.cs
+++ b/Whisper.net/Internals/Native/NativeMethods.cs
@@ -64,6 +64,10 @@ internal static class NativeMethods
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern float whisper_full_get_token_p_from_state(IntPtr state, int segmentIndex, int tokenIndex);
 
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public static extern bool whisper_full_get_segment_speaker_turn_next(IntPtr ctx, int iSegment);
+
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern int whisper_tokenize(IntPtr context, IntPtr text, IntPtr tokens, int nMaxTokens);
 
@@ -87,6 +91,9 @@ internal static class NativeMethods
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern IntPtr whisper_init_state(IntPtr context);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public static extern IntPtr whisper_ctx_init_openvino_encoder(IntPtr context, string path, string device, string cacheDir);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern void whisper_free_state(IntPtr state);


### PR DESCRIPTION
The newest whisper.cpp introduced some breaking changes in WhisperFullParams (Why they felt the need to add them here and break every other implementation for a debug variable is beyond me). This bumps the underlying dependency and adds the new APIs to the NativeMethods.cs