### PR TITLE
Fixed vulkan and coreml targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,7 +363,7 @@ MigrationBackup/
 !/runtimes/Whisper.net.Runtime.Cuda.*/Whisper.net.Runtime.Cuda.*.targets
 
 /runtimes/Whisper.net.Runtime.Vulkan/*
-!/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets
+!/runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets
 
 /runtimes/Whisper.net.Runtime.CoreML/*
 !/runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets

--- a/runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets
+++ b/runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets
@@ -103,14 +103,22 @@
       <TargetPath>libwhisper.coreml.dylib</TargetPath>
     </None>
   </ItemGroup>
-  <ItemGroup>
+  <!-- Metal Maui asset for maccatalyst, ios, tvos and their simulators -->
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or (('$(Platform)' == 'iPhone') OR ('$(RuntimeIdentifier)' == 'ios') OR $(RuntimeIdentifier.StartsWith('ios-')) OR $(RuntimeIdentifier.StartsWith('ios.'))) or $(TargetFramework.Contains('-maccatalyst')) == true or (('$(Platform)' == 'iPhoneSimulator') OR $(RuntimeIdentifier.StartsWith('iossimulator')))">
+    <MauiAsset Include="$(MSBuildThisFileDirectory)\ggml-metal.metal" LogicalName="ggml-metal.metal" />
+  </ItemGroup>
+
+  <!-- Metal Copy For MacOS -->
+  <ItemGroup Condition="$(TargetFramework.Contains('-')) == false">
     <None Visible="false" Include="$(MSBuildThisFileDirectory)\ggml-metal.metal">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>ggml-metal.metal</TargetPath>
+      <PublishFolderType>RootDirectory</PublishFolderType>
     </None>
   </ItemGroup>
+
   <ItemGroup Condition="$(TargetFramework.Contains('-')) == false ">
     <None Visible="false" Include="$(MSBuildThisFileDirectory)macos-x64\libwhisper.dylib">
       <Pack>true</Pack>

--- a/runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets
+++ b/runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets
@@ -1,0 +1,17 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup
+      Condition="$(TargetFramework.Contains('-windows')) == true or $(TargetFramework.Contains('-')) == false">
+    <None Visible="false" Include="$(MSBuildThisFileDirectory)win-x64\whisper.dll">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>runtimes/vulkan/win-x64/whisper.dll</TargetPath>
+    </None>
+    <None Visible="false" Include="$(MSBuildThisFileDirectory)win-x64\ggml.dll">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>runtimes/vulkan/win-x64/ggml.dll</TargetPath>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This pull request includes several updates to the build configurations for the Whisper.net runtime, specifically targeting different platforms and frameworks. The most important changes involve adding support for Metal and Vulkan assets and ensuring proper handling of these assets across various platforms.

### Updates to Metal and Vulkan asset handling:

* [`runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets`](diffhunk://#diff-43931768d430a4d2f29c47b1d3745781ad50e92fcf78eb782952e58100f45e40L106-R121): Added conditions to include the `ggml-metal.metal` asset for maccatalyst, iOS, tvOS, and their simulators, and ensured the asset is copied correctly for MacOS targets.

* [`runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets`](diffhunk://#diff-06af01bfa48360bebc6c9fc706d493cab542edb77a60f7c921454c664432dc5aR1-R17): Introduced a new project file to handle Vulkan assets for Windows targets, ensuring the `whisper.dll` and `ggml.dll` are included and copied to the output directory.