### PR TITLE
Removed unused param and direct reference in cuda sample

### DIFF
--- a/Whisper.net/LibraryLoader/ILibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/ILibraryLoader.cs
@@ -4,7 +4,7 @@ namespace Whisper.net.LibraryLoader;
 
 internal interface ILibraryLoader
 {
-    IntPtr OpenLibrary(string fileName, bool global);
+    IntPtr OpenLibrary(string fileName);
 
     string GetLastError();
 }

--- a/Whisper.net/LibraryLoader/LinuxLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/LinuxLibraryLoader.cs
@@ -18,16 +18,16 @@ internal class LinuxLibraryLoader : ILibraryLoader
     [DllImport("libdl.so.2", ExactSpelling = true, CharSet = CharSet.Auto, EntryPoint = "dlerror")]
     public static extern IntPtr GetLoadError2();
 
-    public IntPtr OpenLibrary(string fileName, bool global)
+    public IntPtr OpenLibrary(string fileName)
     {
         try
         {
-            // open with rtld now + (global if true)
-            return NativeOpenLibraryLibdl2(fileName, global ? 0x00102 : 0x00002);
+            // open with rtld now + global
+            return NativeOpenLibraryLibdl2(fileName, 0x00102);
         }
         catch (DllNotFoundException)
         {
-            return NativeOpenLibraryLibdl(fileName, global ? 0x00102 : 0x00002);
+            return NativeOpenLibraryLibdl(fileName, 0x00102);
         }
     }
 

--- a/Whisper.net/LibraryLoader/MacOsLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/MacOsLibraryLoader.cs
@@ -12,9 +12,9 @@ internal class MacOsLibraryLoader : ILibraryLoader
     [DllImport("libdl.dylib", ExactSpelling = true, CharSet = CharSet.Auto, EntryPoint = "dlerror")]
     public static extern IntPtr GetLoadError();
 
-    public IntPtr OpenLibrary(string fileName, bool global)
+    public IntPtr OpenLibrary(string fileName)
     {
-        return NativeOpenLibraryLibdl(fileName, global ? 0x00102 : 0x00001);
+        return NativeOpenLibraryLibdl(fileName, 0x00102);
     }
 
     public string GetLastError()

--- a/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
@@ -64,7 +64,7 @@ public static class NativeLibraryLoader
             }
             var whisperPath = GetLibraryPath(platform, "whisper", runtimePath);
 
-            var ggmlLibraryHandle = libraryLoader.OpenLibrary(ggmlPath, global: true);
+            var ggmlLibraryHandle = libraryLoader.OpenLibrary(ggmlPath);
             // Maybe GPU is not available but we still have other runtime installed
             if (ggmlLibraryHandle == IntPtr.Zero)
             {
@@ -73,7 +73,7 @@ public static class NativeLibraryLoader
             }
 
             // Ggml was loaded, for this runtimePath, we need to load whisper as well
-            var whisperHandle = libraryLoader.OpenLibrary(whisperPath, global: true);
+            var whisperHandle = libraryLoader.OpenLibrary(whisperPath);
             if (whisperHandle != IntPtr.Zero)
             {
                 RuntimeOptions.Instance.SetLoadedLibrary(runtimeLibrary);

--- a/Whisper.net/LibraryLoader/UniversalLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/UniversalLibraryLoader.cs
@@ -11,7 +11,7 @@ internal class UniversalLibraryLoader : ILibraryLoader
         return "Cannot load the library on this platform using NativeLibrary";
     }
 
-    public IntPtr OpenLibrary(string fileName, bool global)
+    public IntPtr OpenLibrary(string fileName)
     {
         return NativeLibrary.Load(fileName, System.Reflection.Assembly.GetExecutingAssembly(), DllImportSearchPath.AssemblyDirectory);
     }

--- a/Whisper.net/LibraryLoader/WindowsLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/WindowsLibraryLoader.cs
@@ -10,7 +10,7 @@ internal class WindowsLibraryLoader : ILibraryLoader
     [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Auto)]
     private static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPTStr)] string? lpFileName);
 
-    public IntPtr OpenLibrary(string fileName, bool global)
+    public IntPtr OpenLibrary(string fileName)
     {
         return LoadLibrary(fileName);
     }

--- a/examples/NvidiaCuda/NvidiaCuda.csproj
+++ b/examples/NvidiaCuda/NvidiaCuda.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Whisper.net" Version="1.7.0" />-->
+    <PackageReference Include="Whisper.net" Version="1.7.0" />
     <PackageReference Include="Whisper.net.Runtime.Cuda" Version="1.7.0" />
   </ItemGroup>
   
@@ -17,8 +17,4 @@
     </None>
   </ItemGroup>
   
-  <ItemGroup>
-    <ProjectReference Include="..\..\Whisper.net\Whisper.net.csproj" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This pull request includes several changes to the `Whisper.net` library, primarily focusing on simplifying the `OpenLibrary` method across different platform-specific implementations and updating project references in the NvidiaCuda example.

### Simplification of `OpenLibrary` Method:

* [`Whisper.net/LibraryLoader/ILibraryLoader.cs`](diffhunk://#diff-718393293ccb9db83b46a36995bfbfffd5063fe060cd43948cc944ec3a2a28adL7-R7): Removed the `global` parameter from the `OpenLibrary` method in the `ILibraryLoader` interface.
* [`Whisper.net/LibraryLoader/LinuxLibraryLoader.cs`](diffhunk://#diff-7c1a9b168c032a8ba88187e5e56c96a21bfb270ba866a73d3f4b717f5eed6f9dL21-R30): Updated the `OpenLibrary` method to remove the `global` parameter and always use the `0x00102` flag.
* [`Whisper.net/LibraryLoader/MacOsLibraryLoader.cs`](diffhunk://#diff-94d9ea1a95146101723aa7ac2c05af449e0b07300d9c14584bddbbf965862e4eL15-R17): Modified the `OpenLibrary` method to remove the `global` parameter and always use the `0x00102` flag.
* [`Whisper.net/LibraryLoader/NativeLibraryLoader.cs`](diffhunk://#diff-ff57ed519e83a61fa2d11b0278481279c8298ae4836d4a90c271cc5ca372c5eaL67-R67): Adjusted calls to `OpenLibrary` to remove the `global` parameter when loading libraries. [[1]](diffhunk://#diff-ff57ed519e83a61fa2d11b0278481279c8298ae4836d4a90c271cc5ca372c5eaL67-R67) [[2]](diffhunk://#diff-ff57ed519e83a61fa2d11b0278481279c8298ae4836d4a90c271cc5ca372c5eaL76-R76)
* [`Whisper.net/LibraryLoader/UniversalLibraryLoader.cs`](diffhunk://#diff-276ce32c4b01e95f16da2ba0b63142493135d58f64b4e75047c762119653de30L14-R14): Simplified the `OpenLibrary` method by removing the `global` parameter.
* [`Whisper.net/LibraryLoader/WindowsLibraryLoader.cs`](diffhunk://#diff-b823a8dc26417be19f6376083d39ce835122414836cbe36454feb33be9022a61L13-R13): Updated the `OpenLibrary` method to remove the `global` parameter.

### Project Reference Updates:

* [`examples/NvidiaCuda/NvidiaCuda.csproj`](diffhunk://#diff-6cbccda5e815f5847348eda83c9d25e190e2853087f5c2215342abfc99ebfbaeL10-R10): Uncommented the `PackageReference` for `Whisper.net` and removed the `ProjectReference` to `Whisper.net.csproj`. [[1]](diffhunk://#diff-6cbccda5e815f5847348eda83c9d25e190e2853087f5c2215342abfc99ebfbaeL10-R10) [[2]](diffhunk://#diff-6cbccda5e815f5847348eda83c9d25e190e2853087f5c2215342abfc99ebfbaeL20-L23)