### PR TITLE
Fixed the perf issue on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ wasm:
 
 linux_x64:
 	rm -rf build/linux-x64
-	cmake -S . -B build/linux-x64 -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 
+	cmake -S . -B build/linux-x64 -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DGGML_NATIVE=ON
 	cmake --build build/linux-x64 --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime/linux-x64
 	cp build/linux-x64/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime/linux-x64/libwhisper.so
@@ -60,7 +60,7 @@ linux_x64:
 
 linux_arm64:
 	rm -rf build/linux-arm64
-	cmake -S . -B build/linux-arm64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64
+	cmake -S . -B build/linux-arm64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DGGML_NATIVE=ON
 	cmake --build build/linux-arm64 --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime/linux-arm64
 	cp build/linux-arm64/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime/linux-arm64/libwhisper.so
@@ -68,7 +68,7 @@ linux_arm64:
 
 linux_arm:
 	rm -rf build/linux-arm
-	cmake -S . -B build/linux-arm -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm
+	cmake -S . -B build/linux-arm -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm -DGGML_NATIVE=ON
 	cmake --build build/linux-arm --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime/linux-arm
 	cp build/linux-arm/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime/linux-arm/libwhisper.so
@@ -76,7 +76,7 @@ linux_arm:
 
 linux_x64_cuda:
 	rm -rf build/linux-x64-cuda
-	cmake -S . -B build/linux-x64-cuda -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DGGML_CUDA=ON
+	cmake -S . -B build/linux-x64-cuda -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DGGML_CUDA=ON -DGGML_NATIVE=ON
 	cmake --build build/linux-x64-cuda --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime.Cuda.Linux/linux-x64
 	cp build/linux-x64-cuda/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime.Cuda.Linux/linux-x64/libwhisper.so
@@ -108,7 +108,7 @@ linux_arm_noavx:
 
 linux_x64_openvino:
 	rm -rf build/linux-x64-openvino
-	cmake -S . -B build/linux-x64-openvino -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DWHISPER_OPENVINO=ON
+	cmake -S . -B build/linux-x64-openvino -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=x86_64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DWHISPER_OPENVINO=ON -DGGML_NATIVE=ON
 	cmake --build build/linux-x64-openvino --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime.OpenVino/linux-x64
 	cp build/linux-x64-openvino/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime.OpenVino/linux-x64/libwhisper.so
@@ -167,7 +167,7 @@ ios_coreml:
 
 maccatalyst_arm64:
 	rm -rf build/maccatalyst_arm64
-	cmake $(CMAKE_PARAMETERS) -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_HOST_SYSTEM_PROCESSOR=arm64 -DGGML_METAL=OFF -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_CXX_FLAGS="-target arm64-apple-ios13.1-macabi" -DCMAKE_C_FLAGS="-target arm64-apple-ios13.1-macabi" -S . -B build/maccatalyst_arm64
+	cmake $(CMAKE_PARAMETERS)  -S . -B build/maccatalyst_arm64 -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_HOST_SYSTEM_PROCESSOR=arm64 -DGGML_METAL=OFF -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_CXX_FLAGS="-target arm64-apple-ios13.1-macabi" -DCMAKE_C_FLAGS="-target arm64-apple-ios13.1-macabi" -DGGML_NATIVE=ON
 	cmake --build build/maccatalyst_arm64
 	mkdir -p runtimes/Whisper.net.Runtime/maccatalyst
 	cp build/maccatalyst_arm64/whisper.cpp/src/libwhisper.dylib runtimes/Whisper.net.Runtime/maccatalyst/libwhisper.dylib
@@ -175,7 +175,7 @@ maccatalyst_arm64:
 
 maccatalyst_arm64_coreml:
 	rm -rf build/maccatalyst-arm64-coreml
-	cmake $(COREML_SUPPORT) -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_HOST_SYSTEM_PROCESSOR=arm64 -DGGML_METAL=OFF -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_CXX_FLAGS="-target arm64-apple-ios13.1-macabi" -DCMAKE_C_FLAGS="-target arm64-apple-ios13.1-macabi" -S . -B build/maccatalyst-arm64-coreml
+	cmake $(COREML_SUPPORT)  -S . -B build/maccatalyst-arm64-coreml -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_HOST_SYSTEM_PROCESSOR=arm64 -DGGML_METAL=OFF -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_CXX_FLAGS="-target arm64-apple-ios13.1-macabi" -DCMAKE_C_FLAGS="-target arm64-apple-ios13.1-macabi" -DGGML_NATIVE=ON
 	cmake --build build/maccatalyst-arm64-coreml
 	mkdir -p runtimes/Whisper.net.Runtime.CoreML/maccatalyst
 	cp build/maccatalyst-arm64-coreml/whisper.cpp/src/libwhisper.coreml.dylib runtimes/Whisper.net.Runtime.CoreML/maccatalyst/libwhisper.coreml.dylib

--- a/Whisper.net/Internals/Native/INativeWhisper.cs
+++ b/Whisper.net/Internals/Native/INativeWhisper.cs
@@ -73,6 +73,9 @@ internal interface INativeWhisper : IDisposable
     [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public delegate void ggml_log_set(IntPtr logCallback, IntPtr user_data);
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public delegate IntPtr whisper_print_system_info();
+
     whisper_init_from_file_with_params_no_state Whisper_Init_From_File_With_Params_No_State { get; }
     whisper_init_from_buffer_with_params_no_state Whisper_Init_From_Buffer_With_Params_No_State { get; }
     whisper_free Whisper_Free { get; }
@@ -96,4 +99,6 @@ internal interface INativeWhisper : IDisposable
     whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State { get; }
 
     ggml_log_set Ggml_log_set { get; }
+
+    whisper_print_system_info WhisperPrintSystemInfo { get; }
 }

--- a/Whisper.net/Internals/Native/Implementations/DllImportsNativeLibWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/DllImportsNativeLibWhisper.cs
@@ -79,6 +79,9 @@ internal class DllImportsNativeLibWhisper : INativeWhisper
     [DllImport(ggmlLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern void ggml_log_set(IntPtr logCallback, IntPtr user_data);
 
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public static extern IntPtr whisper_print_system_info();
+
     public INativeWhisper.whisper_init_from_file_with_params_no_state Whisper_Init_From_File_With_Params_No_State => whisper_init_from_file_with_params_no_state;
 
     public INativeWhisper.whisper_init_from_buffer_with_params_no_state Whisper_Init_From_Buffer_With_Params_No_State => whisper_init_from_buffer_with_params_no_state;
@@ -122,6 +125,8 @@ internal class DllImportsNativeLibWhisper : INativeWhisper
     public INativeWhisper.whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State => whisper_ctx_init_openvino_encoder_with_state;
 
     public INativeWhisper.ggml_log_set Ggml_log_set => ggml_log_set;
+
+    public INativeWhisper.whisper_print_system_info WhisperPrintSystemInfo => whisper_print_system_info;
 
     public void Dispose()
     {

--- a/Whisper.net/Internals/Native/Implementations/DllImportsNativeWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/DllImportsNativeWhisper.cs
@@ -79,6 +79,9 @@ internal class DllImportsNativeWhisper : INativeWhisper
     [DllImport(ggmlLibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern void ggml_log_set(IntPtr logCallback, IntPtr user_data);
 
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public static extern IntPtr whisper_print_system_info();
+
     public INativeWhisper.whisper_init_from_file_with_params_no_state Whisper_Init_From_File_With_Params_No_State => whisper_init_from_file_with_params_no_state;
 
     public INativeWhisper.whisper_init_from_buffer_with_params_no_state Whisper_Init_From_Buffer_With_Params_No_State => whisper_init_from_buffer_with_params_no_state;
@@ -122,6 +125,8 @@ internal class DllImportsNativeWhisper : INativeWhisper
     public INativeWhisper.whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State => whisper_ctx_init_openvino_encoder_with_state;
 
     public INativeWhisper.ggml_log_set Ggml_log_set => ggml_log_set;
+
+    public INativeWhisper.whisper_print_system_info WhisperPrintSystemInfo => whisper_print_system_info;
 
     public void Dispose()
     {

--- a/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
@@ -78,6 +78,9 @@ internal partial class LibraryImportInternalWhisper : INativeWhisper
     [LibraryImport(libraryName, StringMarshalling = StringMarshalling.Utf8)]
     public static partial void ggml_log_set(IntPtr logCallback, IntPtr user_data);
 
+    [LibraryImport(libraryName, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial IntPtr whisper_print_system_info();
+
     public INativeWhisper.whisper_init_from_file_with_params_no_state Whisper_Init_From_File_With_Params_No_State => whisper_init_from_file_with_params_no_state;
 
     public INativeWhisper.whisper_init_from_buffer_with_params_no_state Whisper_Init_From_Buffer_With_Params_No_State => whisper_init_from_buffer_with_params_no_state;
@@ -121,6 +124,8 @@ internal partial class LibraryImportInternalWhisper : INativeWhisper
     public INativeWhisper.whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State => whisper_ctx_init_openvino_encoder_with_state;
 
     public INativeWhisper.ggml_log_set Ggml_log_set => ggml_log_set;
+
+    public INativeWhisper.whisper_print_system_info WhisperPrintSystemInfo => whisper_print_system_info;
 
     public void Dispose()
     {

--- a/Whisper.net/Internals/Native/Implementations/LibraryImportLibWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/LibraryImportLibWhisper.cs
@@ -79,6 +79,9 @@ internal partial class LibraryImportLibWhisper : INativeWhisper
     [LibraryImport(ggmlLibraryName, StringMarshalling = StringMarshalling.Utf8)]
     public static partial void ggml_log_set(IntPtr logCallback, IntPtr user_data);
 
+    [LibraryImport(libraryName, StringMarshalling = StringMarshalling.Utf8)]
+    public static partial IntPtr whisper_print_system_info();
+
     public INativeWhisper.whisper_init_from_file_with_params_no_state Whisper_Init_From_File_With_Params_No_State => whisper_init_from_file_with_params_no_state;
 
     public INativeWhisper.whisper_init_from_buffer_with_params_no_state Whisper_Init_From_Buffer_With_Params_No_State => whisper_init_from_buffer_with_params_no_state;
@@ -122,6 +125,8 @@ internal partial class LibraryImportLibWhisper : INativeWhisper
     public INativeWhisper.whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State => whisper_ctx_init_openvino_encoder_with_state;
 
     public INativeWhisper.ggml_log_set Ggml_log_set => ggml_log_set;
+
+    public INativeWhisper.whisper_print_system_info WhisperPrintSystemInfo => whisper_print_system_info;
 
     public void Dispose()
     {

--- a/Whisper.net/Internals/Native/Implementations/NativeLibraryWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/NativeLibraryWhisper.cs
@@ -35,6 +35,7 @@ internal class NativeLibraryWhisper : INativeWhisper
         Whisper_Log_Set = Marshal.GetDelegateForFunctionPointer<whisper_log_set>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_log_set)));
         Whisper_Ctx_Init_Openvino_Encoder_With_State = Marshal.GetDelegateForFunctionPointer<whisper_ctx_init_openvino_encoder_with_state>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_ctx_init_openvino_encoder_with_state)));
         Ggml_log_set = Marshal.GetDelegateForFunctionPointer<ggml_log_set>(NativeLibrary.GetExport(ggmlLibraryHandle, nameof(ggml_log_set)));
+        WhisperPrintSystemInfo = Marshal.GetDelegateForFunctionPointer<whisper_print_system_info>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_print_system_info)));
 
         this.whisperLibraryHandle = whisperLibraryHandle;
         this.ggmlLibraryHandle = ggmlLibraryHandle;
@@ -83,6 +84,8 @@ internal class NativeLibraryWhisper : INativeWhisper
     public whisper_ctx_init_openvino_encoder_with_state Whisper_Ctx_Init_Openvino_Encoder_With_State { get; }
 
     public ggml_log_set Ggml_log_set { get; }
+
+    public whisper_print_system_info WhisperPrintSystemInfo { get; }
 
     public void Dispose()
     {

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -1,5 +1,6 @@
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 
+using System.Runtime.InteropServices;
 using Whisper.net.Internals.ModelLoader;
 using Whisper.net.LibraryLoader;
 using Whisper.net.Logger;
@@ -45,6 +46,19 @@ public sealed class WhisperFactory : IDisposable
         {
             contextLazy = new Lazy<IntPtr>(() => loader.LoadNativeContext(libraryLoaded.Value.NativeWhisper!), isThreadSafe: false);
         }
+    }
+
+    public static string? GetSystemInfo()
+    {
+        if (!libraryLoaded.Value.IsSuccess)
+        {
+            throw new Exception($"Failed to load native whisper library. Error: {libraryLoaded.Value.ErrorMessage}");
+        }
+
+        var systemInfoPtr = libraryLoaded.Value.NativeWhisper!.WhisperPrintSystemInfo();
+        var systemInfoStr = Marshal.PtrToStringAnsi(systemInfoPtr);
+        Marshal.FreeHGlobal(systemInfoPtr);
+        return systemInfoStr;
     }
 
     /// <summary>

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -48,7 +48,7 @@ public sealed class WhisperFactory : IDisposable
         }
     }
 
-    public static string? GetSystemInfo()
+    public static string? GetRuntimeInfo()
     {
         if (!libraryLoaded.Value.IsSuccess)
         {

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -48,6 +48,13 @@ public sealed class WhisperFactory : IDisposable
         }
     }
 
+    /// <summary>
+    /// Returns the information about the loaded native runtime.
+    /// </summary>
+    /// <remarks>
+    /// This information includes support of the features like AVX, AVX2, AVX512, CUDA, etc.
+    /// </remarks>
+    /// <exception cref="Exception"></exception>
     public static string? GetRuntimeInfo()
     {
         if (!libraryLoaded.Value.IsSuccess)


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` to enable native optimizations and updates to the `INativeWhisper` interface and its implementations to support a new method for printing system information.

### Makefile Enhancements:
* Added the `-DGGML_NATIVE=ON` flag to various build configurations in the `Makefile` to enable native optimizations. (`Makefile`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L55-R79) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L111-R111) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L170-R178)

### Interface and Implementation Updates:
* Introduced a new delegate `whisper_print_system_info` in the `INativeWhisper` interface to allow printing system information. (`Whisper.net/Internals/Native/INativeWhisper.cs`) [[1]](diffhunk://#diff-546c9261e9d4c24c7c88512fb9766a028fe551b944f5aa308058b39343ef686dR76-R78) [[2]](diffhunk://#diff-546c9261e9d4c24c7c88512fb9766a028fe551b944f5aa308058b39343ef686dR102-R103)
* Added the `whisper_print_system_info` method to the `DllImportsNativeLibWhisper`, `DllImportsNativeWhisper`, `LibraryImportInternalWhisper`, and `LibraryImportLibWhisper` classes. (`Whisper.net/Internals/Native/Implementations/DllImportsNativeLibWhisper.cs`, `Whisper.net/Internals/Native/Implementations/DllImportsNativeWhisper.cs`, `Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs`, `Whisper.net/Internals/Native/Implementations/LibraryImportLibWhisper.cs`) [[1]](diffhunk://#diff-84a140cfdfc53403105ca7cffcabbb8e4ecf95677193ea0b8b2d8b4cf31695a2R82-R84) [[2]](diffhunk://#diff-84a140cfdfc53403105ca7cffcabbb8e4ecf95677193ea0b8b2d8b4cf31695a2R129-R130) [[3]](diffhunk://#diff-f3fb7dcdf6b869e0f5b6dad134d9829d57906ed061e3245be06a074184a89f6aR82-R84) [[4]](diffhunk://#diff-f3fb7dcdf6b869e0f5b6dad134d9829d57906ed061e3245be06a074184a89f6aR129-R130) [[5]](diffhunk://#diff-0cb77079b5cd2054a6d94e4246692db327fa1f39d0a1a8d80634cb07bcfeef4fR81-R83) [[6]](diffhunk://#diff-0cb77079b5cd2054a6d94e4246692db327fa1f39d0a1a8d80634cb07bcfeef4fR128-R129) [[7]](diffhunk://#diff-3e544f8d277a0203522c297d2f0537de1e0c8cfb980dd2ff57698528d2245685R82-R84) [[8]](diffhunk://#diff-3e544f8d277a0203522c297d2f0537de1e0c8cfb980dd2ff57698528d2245685R129-R130)
* Updated the `NativeLibraryWhisper` class to include the `whisper_print_system_info` method. (`Whisper.net/Internals/Native/Implementations/NativeLibraryWhisper.cs`) [[1]](diffhunk://#diff-353b605f2c6ef075a1367c0398e0430369d7ed8d1a0717b1f720710a0d795e7aR38) [[2]](diffhunk://#diff-353b605f2c6ef075a1367c0398e0430369d7ed8d1a0717b1f720710a0d795e7aR88-R89)

### New Functionality in WhisperFactory:
* Added a `GetSystemInfo` method to the `WhisperFactory` class to retrieve system information using the newly introduced delegate. (`Whisper.net/WhisperFactory.cs`) [[1]](diffhunk://#diff-d5e496f04b45a146de7fffa6b94601c9914d63fcedb85624efbcb96b7a5cbbeaR3) [[2]](diffhunk://#diff-d5e496f04b45a146de7fffa6b94601c9914d63fcedb85624efbcb96b7a5cbbeaR51-R63)