### PR TITLE
Fix RuntimeOptions example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,15 @@ The following order of priority will be used by default:
 
 To change the order or force a specific runtime, set the `RuntimeOrder` on the `RuntimeOptions`:
 
-`` RuntimeOptions.SetRuntimeLibraryOrder(new[] { RuntimeLibrary.CoreML, RuntimeLibrary.OpenVino, RuntimeLibrary.Cuda, RuntimeLibrary.Cpu }); ``
+```csharp
+RuntimeOptions.Instance.SetRuntimeLibraryOrder(new List<RuntimeLibrary>()
+{
+    RuntimeLibrary.CoreML,
+    RuntimeLibrary.OpenVino,
+    RuntimeLibrary.Cuda,
+    RuntimeLibrary.Cpu
+});
+```
 
 ## Versioning
 


### PR DESCRIPTION
In the README.md, the example to change the runtime order is missing `.Instance` and also the parameter should be a List and not an array in order to compile.