### PR TITLE
fix linux cuda broken in 1.7.1

### DIFF
--- a/Whisper.net/Internals/Native/Implementations/Cuda/DllImportNativeCuda.cs
+++ b/Whisper.net/Internals/Native/Implementations/Cuda/DllImportNativeCuda.cs
@@ -20,7 +20,7 @@ internal class DllImportNativeCuda_64_12 : INativeCuda
 
 internal class DllImportNativeLibcuda : INativeCuda
 {
-    public const string LibraryName = "libcudart";
+    public const string LibraryName = "libcudart.so";
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int cudaGetDeviceCount(out int count);


### PR DESCRIPTION
linux-x64 CUDA was working for me in whisper.net 1.7.0 but stopped working in 1.7.1. IsCudaAvailable() returns false trying to load the library "libcudart".  This commit changing it to "libcudart.so" makes it work again for me.

I'm using Linux Mint 22 with NVIDIA drivers 555.42.02 and CUDA 12.5, let me know if you need more info about my system.
