### PR TITLE
Fixed linux performance by adding F16C to list of required specialized instructions.

### DIFF
--- a/.github/workflows/windows-noavx-native-build.yml
+++ b/.github/workflows/windows-noavx-native-build.yml
@@ -22,7 +22,6 @@ jobs:
           Import-Module ./windows-scripts.ps1
           BuildWindows -Arch "x64" -Configuration "Release"  -NoAvx $true
           BuildWindows -Arch "x86" -Configuration "Release"  -NoAvx $true
-          BuildWindows -Arch "arm64" -Configuration "Release"  -NoAvx $true
         shell: pwsh
 
       - name: Upload Windows NoAvx Build Artifacts

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ apple_coreml_arm: macos_arm64_coreml ios_coreml  maccatalyst_arm64_coreml ios_si
 
 linux: linux_x64 linux_arm64 linux_arm
 
-linux_noavx: linux_x64_noavx linux_arm64_noavx linux_arm_noavx
+linux_noavx: linux_x64_noavx
 
 linux_cuda: linux_x64_cuda
 
@@ -92,21 +92,6 @@ linux_x64_noavx:
 	cp build/linux-x64-noavx/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-x64/libwhisper.so
 	cp build/linux-x64-noavx/whisper.cpp/ggml/src/libggml.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-x64/libggml.so
 
-linux_arm64_noavx:
-	rm -rf build/linux-arm64-noavx
-	cmake -S . -B build/linux-arm64-noavx -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 $(NOAVX_SUPPORT)
-	cmake --build build/linux-arm64-noavx --config $(BUILD_TYPE)
-	mkdir -p runtimes/Whisper.net.Runtime.NoAvx/linux-arm64
-	cp build/linux-arm64-noavx/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-arm64/libwhisper.so
-	cp build/linux-arm64-noavx/whisper.cpp/ggml/src/libggml.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-arm64/libggml.so
-
-linux_arm_noavx:
-	rm -rf build/linux-arm-noavx
-	cmake -S . -B build/linux-arm-noavx -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm $(NOAVX_SUPPORT)
-	cmake --build build/linux-arm-noavx --config $(BUILD_TYPE)
-	mkdir -p runtimes/Whisper.net.Runtime.NoAvx/linux-arm
-	cp build/linux-arm-noavx/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-arm/libwhisper.so
-	cp build/linux-arm-noavx/whisper.cpp/ggml/src/libggml.so ./runtimes/Whisper.net.Runtime.NoAvx/linux-arm/libggml.so
 
 linux_x64_openvino:
 	rm -rf build/linux-x64-openvino

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BUILD_TYPE=Release
 CMAKE_PARAMETERS=-DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 COREML_SUPPORT=$(CMAKE_PARAMETERS) -DWHISPER_COREML=ON -DWHISPER_COREML_ALLOW_FALLBACK=ON
-AVX_SUPPORT=-DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON
-NOAVX_SUPPORT=-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF
+AVX_SUPPORT=-DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON
+NOAVX_SUPPORT=-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
 NDK := $(if $(strip $(NDK_PATH)),$(NDK_PATH),$(shell test -d $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle && echo $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle || echo ""))
 
 nuget:
@@ -62,7 +62,7 @@ linux_x64:
 
 linux_arm64:
 	rm -rf build/linux-arm64
-	cmake -S . -B build/linux-arm64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 $(AVX_SUPPORT)
+	cmake -S . -B build/linux-arm64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64
 	cmake --build build/linux-arm64 --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime/linux-arm64
 	cp build/linux-arm64/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime/linux-arm64/libwhisper.so
@@ -70,7 +70,7 @@ linux_arm64:
 
 linux_arm:
 	rm -rf build/linux-arm
-	cmake -S . -B build/linux-arm -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm $(AVX_SUPPORT)
+	cmake -S . -B build/linux-arm -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm
 	cmake --build build/linux-arm --config $(BUILD_TYPE)
 	mkdir -p runtimes/Whisper.net.Runtime/linux-arm
 	cp build/linux-arm/whisper.cpp/src/libwhisper.so ./runtimes/Whisper.net.Runtime/linux-arm/libwhisper.so

--- a/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
@@ -44,7 +44,16 @@ public static class NativeLibraryLoader
             _ when RuntimeInformation.IsOSPlatform(OSPlatform.Windows) => "win",
             _ when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => "linux",
             _ when RuntimeInformation.IsOSPlatform(OSPlatform.OSX) => "macos",
-            _ => throw new PlatformNotSupportedException($"Unsupported OS platform, architecture: {RuntimeInformation.OSArchitecture}")
+            _ => throw new PlatformNotSupportedException($"Unsupported OS Version")
+        };
+
+        var architecture = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm => "arm",
+            Architecture.Arm64 => "arm64",
+            _ => throw new PlatformNotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}")
         };
 
 #if NETSTANDARD
@@ -60,12 +69,12 @@ public static class NativeLibraryLoader
 
         string? lastError = null;
 
-        var availableRuntimes = GetRuntimePaths(platform).ToList();
+        var availableRuntimes = GetRuntimePaths(architecture, platform).ToList();
         var availableRuntimeTypes = availableRuntimes.Select(x => x.RuntimeLibrary).ToList();
 
         foreach (var (runtimePath, runtimeLibrary) in availableRuntimes)
         {
-            if (!IsRuntimeSupported(runtimeLibrary, platform, availableRuntimeTypes))
+            if (!IsRuntimeSupported(runtimeLibrary, platform, architecture, availableRuntimeTypes))
             {
                 continue;
             }
@@ -132,14 +141,17 @@ public static class NativeLibraryLoader
         return Path.Combine(runtimePath, libraryFileName);
     }
 
-    private static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, List<RuntimeLibrary> runtimeLibraries)
+    private static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, string architecture, List<RuntimeLibrary> runtimeLibraries)
     {
         LogProvider.Log(WhisperLogLevel.Debug, $"Checking if runtime {runtime} is supported on the platform: {platform}");
 #if !NETSTANDARD
         // If AVX is not supported, we can't use CPU runtime on Windows and linux (we should use noavx runtime instead).
-        if (runtime == RuntimeLibrary.Cpu && (platform == "win" || platform == "linux") && !Avx.IsSupported && !Avx2.IsSupported)
+        if (runtime == RuntimeLibrary.Cpu
+            && (platform == "win" || platform == "linux")
+            && (architecture == "x86" || architecture == "x64")
+            && (!Avx.IsSupported || !Avx2.IsSupported || !Fma.IsSupported))
         {
-            LogProvider.Log(WhisperLogLevel.Debug, $"No AVX or AVX2 support is identified on this host.");
+            LogProvider.Log(WhisperLogLevel.Debug, $"No AVX, AVX2 or Fma support is identified on this host. AVX: {Avx.IsSupported} AVX2: {Avx2.IsSupported} FMA: {Fma.IsSupported}");
             // If noavx runtime is not available, we should throw an exception, because we can't use CPU runtime without AVX support.
             if (!runtimeLibraries.Contains(RuntimeLibrary.CpuNoAvx))
             {
@@ -174,17 +186,8 @@ public static class NativeLibraryLoader
 
     }
 
-    private static IEnumerable<(string RuntimePath, RuntimeLibrary RuntimeLibrary)> GetRuntimePaths(string platform)
+    private static IEnumerable<(string RuntimePath, RuntimeLibrary RuntimeLibrary)> GetRuntimePaths(string architecture, string platform)
     {
-        var architecture = RuntimeInformation.OSArchitecture switch
-        {
-            Architecture.X64 => "x64",
-            Architecture.X86 => "x86",
-            Architecture.Arm => "arm",
-            Architecture.Arm64 => "arm64",
-            _ => throw new PlatformNotSupportedException($"Unsupported OS platform, architecture: {RuntimeInformation.OSArchitecture}")
-        };
-
         var assemblyLocation = typeof(NativeLibraryLoader).Assembly.Location;
         var environmentAppStartLocation = Environment.GetCommandLineArgs()[0];
         // NetFramework and Mono will crash if we try to get the directory of an empty string.

--- a/readme.md
+++ b/readme.md
@@ -62,10 +62,10 @@ The default runtime that uses the CPU for inference. It is available on all plat
 
 #### Pre-requisites
 
- - AVX2 support on the CPU
  - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2019 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
  - Linux: `libstdc++6`
  - macOS: TBD
+ - For x86/x64 platforms, the CPU must support AVX, AVX2, FMA and F16C instructions. If your CPU does not support these instructions, you'll need to use the `Whisper.net.Runtime.NoAvx` runtime instead.
   
 #### Supported Platforms
 

--- a/runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets
+++ b/runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets
@@ -1,18 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <!-- Start Linux -->
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)linux-arm64\libwhisper.so">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/linux-arm64/libwhisper.so</TargetPath>
-    </None>
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)linux-arm64\libggml.so">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/linux-arm64/libggml.so</TargetPath>
-    </None>
     <None Visible="false" Include="$(MSBuildThisFileDirectory)linux-x64\libwhisper.so">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
@@ -25,32 +13,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>runtimes/noavx/linux-x64/libggml.so</TargetPath>
     </None>
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)linux-arm\libwhisper.so">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/linux-arm/libwhisper.so</TargetPath>
-    </None>
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)linux-arm\libggml.so">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/linux-arm/libggml.so</TargetPath>
-    </None>
     <!-- End Linux -->
     <!-- Start Windows -->
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)win-arm64\whisper.dll">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/win-arm64/whisper.dll</TargetPath>
-    </None>
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)win-arm64\ggml.dll">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>runtimes/noavx/win-arm64/ggml.dll</TargetPath>
-    </None>
     <None Visible="false" Include="$(MSBuildThisFileDirectory)win-x64\whisper.dll">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>

--- a/windows-scripts.ps1
+++ b/windows-scripts.ps1
@@ -55,7 +55,7 @@ function BuildWindows() {
     
     $buildDirectory = "build/win-$Arch"
     $options = @("-S", ".", "-DGGML_NATIVE=OFF");
-    $avxOptions = @("-DGGML_AVX=ON", "-DGGML_AVX2=ON", "-DGGML_FMA=ON", "-GGML_F16C=ON");
+    $avxOptions = @("-DGGML_AVX=ON", "-DGGML_AVX2=ON", "-DGGML_FMA=ON", "-DGGML_F16C=ON");
     
     $runtimePath = "./runtimes/Whisper.net.Runtime"
 
@@ -78,7 +78,7 @@ function BuildWindows() {
     }
 
     if ($NoAvx) {
-        $avxOptions = @("-DGGML_AVX=OFF", "-DGGML_AVX2=OFF", "-DGGML_FMA=OFF", "-GGML_F16C=OFF");
+        $avxOptions = @("-DGGML_AVX=OFF", "-DGGML_AVX2=OFF", "-DGGML_FMA=OFF", "-DGGML_F16C=OFF");
         $buildDirectory += "-noavx"
         $runtimePath += ".NoAvx"
     }

--- a/windows-scripts.ps1
+++ b/windows-scripts.ps1
@@ -55,7 +55,7 @@ function BuildWindows() {
     
     $buildDirectory = "build/win-$Arch"
     $options = @("-S", ".", "-DGGML_NATIVE=OFF");
-    $avxOptions = @("-DGGML_AVX=ON", "-DGGML_AVX2=ON", "-DGGML_FMA=ON");
+    $avxOptions = @("-DGGML_AVX=ON", "-DGGML_AVX2=ON", "-DGGML_FMA=ON", "-GGML_F16C=ON");
     
     $runtimePath = "./runtimes/Whisper.net.Runtime"
 
@@ -78,7 +78,7 @@ function BuildWindows() {
     }
 
     if ($NoAvx) {
-        $avxOptions = @("-DGGML_AVX=OFF", "-DGGML_AVX2=OFF", "-DGGML_FMA=OFF");
+        $avxOptions = @("-DGGML_AVX=OFF", "-DGGML_AVX2=OFF", "-DGGML_FMA=OFF", "-GGML_F16C=OFF");
         $buildDirectory += "-noavx"
         $runtimePath += ".NoAvx"
     }


### PR DESCRIPTION
I was using -DGGML_NATIVE=ON before which was just using all the instructions available on the build machine (including F16C).

Once I removed it during https://github.com/sandrohanea/whisper.net/commit/5ddb2c7810e100b71bf70f576bd6a76bfa56cb16 it started to be a lot slower.

F16C instruction is utilized heavily during CPU inference.