### PR TITLE
Fixed the issue with the eager init context that is not freeing memory.

### DIFF
--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -39,7 +39,12 @@ public sealed class WhisperFactory : IDisposable
         {
             var nativeContext = loader.LoadNativeContext(libraryLoaded.Value.NativeWhisper!);
             isEagerlyInitialized = true;
+
+#if NET8_0_OR_GREATER
+            contextLazy = new Lazy<IntPtr>(nativeContext);
+#else
             contextLazy = new Lazy<IntPtr>(() => nativeContext);
+#endif
         }
         else
         {

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -140,7 +140,7 @@ public sealed class WhisperFactory : IDisposable
             return;
         }
 
-        // Even if the Lazy is not initialized, we still need to free the context if it was eagerly initialized.
+        // Even if the Lazy value was not created, we still need to free the context if it was eagerly initialized.
         if ((contextLazy.IsValueCreated || isEagerlyInitialized) && contextLazy.Value != IntPtr.Zero)
         {
             libraryLoaded.Value.NativeWhisper!.Whisper_Free(contextLazy.Value);


### PR DESCRIPTION
Fixing #256 
This pull request includes changes to the `Whisper.net/WhisperFactory.cs` file to improve the handling of the initialization state and disposal logic of the `WhisperFactory` class. The most important changes are the addition of a new field to track if the factory was eagerly initialized and adjustments to the disposal logic to account for this state.

Initialization and disposal improvements:

* [`Whisper.net/WhisperFactory.cs`](diffhunk://#diff-d5e496f04b45a146de7fffa6b94601c9914d63fcedb85624efbcb96b7a5cbbeaR20): Added a new private readonly field `isEagerlyInitialized` to track whether the factory was eagerly initialized.
* [`Whisper.net/WhisperFactory.cs`](diffhunk://#diff-d5e496f04b45a146de7fffa6b94601c9914d63fcedb85624efbcb96b7a5cbbeaR41): Set `isEagerlyInitialized` to `true` if the factory is not delay-initialized in the constructor.
* [`Whisper.net/WhisperFactory.cs`](diffhunk://#diff-d5e496f04b45a146de7fffa6b94601c9914d63fcedb85624efbcb96b7a5cbbeaL140-R144): Updated the `Dispose` method to check `isEagerlyInitialized` when determining whether to free the context, ensuring proper disposal even if the Lazy is not initialized.