### PR TITLE
Fix static linking for iOS

### DIFF
--- a/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
@@ -10,7 +10,7 @@ namespace Whisper.net.Internals.Native.Implementations;
 /// </summary>
 internal partial class LibraryImportInternalWhisper : INativeWhisper
 {
-    const string libraryName = "_Internal";
+    const string libraryName = "__Internal";
 
     [LibraryImport(libraryName, StringMarshalling = StringMarshalling.Utf8)]
     public static partial IntPtr whisper_init_from_file_with_params_no_state(string path, WhisperContextParams whisperContextParams);


### PR DESCRIPTION
Fixes [issue](https://github.com/sandrohanea/whisper.net/issues/178) with `System.DllNotFoundException: __Internal` on iOS devices.