### PR TITLE
Fixing nuget vulkan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
       uses: ./.github/workflows/linux-openvino-native-build.yml
       
    linux-vulkan:
-      if: ${{ inputs.BuildGpuLibs == 'true' }}
       uses: ./.github/workflows/linux-vulkan-native-build.yml
 
    macos-coreml:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
 
    linux-openvino:
       uses: ./.github/workflows/linux-openvino-native-build.yml
+      
+   linux-vulkan:
+      if: ${{ inputs.BuildGpuLibs == 'true' }}
+      uses: ./.github/workflows/linux-vulkan-native-build.yml
 
    macos-coreml:
       uses: ./.github/workflows/macos-coreml-native-build.yml
@@ -78,11 +82,12 @@ jobs:
          - windows-cuda
          - windows-vulkan
          - windows-openvino
+         - windows-no-avx
          - linux-cuda
          - linux-openvino
-         - macos-coreml
          - linux-no-avx
-         - windows-no-avx
+         - linux-vulkan
+         - macos-coreml
       uses: ./.github/workflows/pack-all.yml
       with:
          IsPreview: ${{ inputs.IsPreview }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/release.yml` file to add new build jobs and reorder existing ones. The most important changes include adding a new build job for Linux with Vulkan, reordering the list of jobs, and ensuring that the `windows-no-avx` job is correctly positioned.

### Updates to build jobs:

* Added a new job for Linux with Vulkan (`linux-vulkan`) that runs conditionally based on the `BuildGpuLibs` input.

### Reordering of jobs:

* Reordered the list of jobs to ensure correct execution order and fixed the positioning of the `windows-no-avx` job.