### PR TITLE
Support setting custom alignment heads for dtw

### DIFF
--- a/Whisper.net/Ggml/GgmlType.cs
+++ b/Whisper.net/Ggml/GgmlType.cs
@@ -37,8 +37,14 @@ public enum WhisperAlignmentHeadsPreset
     LargeV3Turbo
 }
 
-public struct WhisperAlignmentHead
+public class WhisperAlignmentHead
 {
     public int TextLayer;
     public int Head;
+
+    public WhisperAlignmentHead(int textLayer, int head)
+    {
+        TextLayer = textLayer;
+        Head = head;
+    }
 }

--- a/Whisper.net/Ggml/GgmlType.cs
+++ b/Whisper.net/Ggml/GgmlType.cs
@@ -36,3 +36,9 @@ public enum WhisperAlignmentHeadsPreset
     LargeV3,
     LargeV3Turbo
 }
+
+public struct WhisperAlignmentHead
+{
+    public int TextLayer;
+    public int Head;
+}

--- a/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
+++ b/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
@@ -1,5 +1,6 @@
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 
+using System.Runtime.InteropServices;
 using Whisper.net.Internals.Native;
 using Whisper.net.LibraryLoader;
 using Whisper.net.Native;
@@ -8,13 +9,49 @@ namespace Whisper.net.Internals.ModelLoader;
 
 internal sealed class WhisperProcessorModelFileLoader(string pathModel) : IWhisperProcessorModelLoader
 {
+    private GCHandle aheadsHandle;
+
     public void Dispose()
     {
+        if (aheadsHandle.IsAllocated)
+        {
+            aheadsHandle.Free();
+        }
+    }
 
+    public static WhisperAheads GetWhisperAlignmentHeads(Ggml.WhisperAlignmentHead[]? alignmentHeads, ref GCHandle aHeadsHandle)
+    {
+        var aHeadsPtr = IntPtr.Zero;
+        var nHeads = alignmentHeads?.Length ?? 0;
+
+        if (nHeads > 0)
+        {
+            var aHeads = new int[nHeads * 2];
+            if (aHeadsHandle.IsAllocated)
+            {
+                aHeadsHandle.Free();
+            }
+            aHeadsHandle = GCHandle.Alloc(aHeads, GCHandleType.Pinned);
+            aHeadsPtr = aHeadsHandle.AddrOfPinnedObject();
+
+            for (var i = 0; i < nHeads; i++)
+            {
+                aHeads[i * 2] = alignmentHeads![i].TextLayer;
+                aHeads[i * 2 + 1] = alignmentHeads[i].Head;
+            }
+        }
+
+        return new WhisperAheads()
+        { 
+            NHeads = (nuint)nHeads,
+            Heads = aHeadsPtr
+        };
     }
 
     public IntPtr LoadNativeContext(INativeWhisper nativeWhisper)
     {
+        var aHeads = GetWhisperAlignmentHeads(RuntimeOptions.Instance.CustomAlignmentHeads, ref aheadsHandle);
+
         return nativeWhisper.Whisper_Init_From_File_With_Params_No_State(pathModel,
            new WhisperContextParams()
            {
@@ -24,11 +61,7 @@ internal sealed class WhisperProcessorModelFileLoader(string pathModel) : IWhisp
                DtwTokenLevelTimestamp = RuntimeOptions.Instance.UseDtwTimeStamps ? (byte)1 : (byte)0,
                HeadsPreset = (WhisperAlignmentHeadsPreset)RuntimeOptions.Instance.HeadsPreset,
                DtwNTop = -1,
-               WhisperAheads = new WhisperAheads()
-               {
-                   NHeads = 0,
-                   Heads = IntPtr.Zero
-               },
+               WhisperAheads = aHeads,
                Dtw_mem_size = 1024 * 1024 * 128,
            });
     }

--- a/Whisper.net/LibraryLoader/RuntimeOptions.cs
+++ b/Whisper.net/LibraryLoader/RuntimeOptions.cs
@@ -13,6 +13,7 @@ public class RuntimeOptions
     internal bool UseFlashAttention { get; private set; }
     internal bool UseDtwTimeStamps { get; private set; }
     internal WhisperAlignmentHeadsPreset HeadsPreset { get; private set; }
+    internal WhisperAlignmentHead[]? CustomAlignmentHeads { get; private set; }
     internal int GpuDevice { get; private set; }
     internal List<RuntimeLibrary> RuntimeLibraryOrder { get; private set; }
     internal RuntimeLibrary? LoadedLibrary { get; private set; }
@@ -27,6 +28,7 @@ public class RuntimeOptions
         UseFlashAttention = false;
         UseDtwTimeStamps = false;
         HeadsPreset = WhisperAlignmentHeadsPreset.None;
+        CustomAlignmentHeads = null;
         RuntimeLibraryOrder = defaultRuntimeOrder;
         GpuDevice = 0;
     }
@@ -128,6 +130,17 @@ public class RuntimeOptions
     }
 
     /// <summary>
+    /// Sets custom attention heads array for DTW. 
+    /// </summary>
+    /// <remarks>
+    /// By default, it is null. Required when using DTW with models which don't have a matching WhisperAlignmentHeadsPreset.
+    /// </remarks>
+    public void SetAlignmentHeads(WhisperAlignmentHead[]? alignmentHeads)
+    {
+        CustomAlignmentHeads = alignmentHeads;
+    }
+
+    /// <summary>
     /// Resets the runtime options to their default values.
     /// </summary>
     public void Reset()
@@ -138,6 +151,7 @@ public class RuntimeOptions
         UseFlashAttention = false;
         UseDtwTimeStamps = false;
         HeadsPreset = WhisperAlignmentHeadsPreset.None;
+        CustomAlignmentHeads = null;
         RuntimeLibraryOrder = defaultRuntimeOrder;
         GpuDevice = 0;
     }


### PR DESCRIPTION
This PR adds the ability to configure a custom attention heads array to enable DTW time alignment when using non-standard Whisper models which don't have a named preset configured in WhisperAlignmentHeadsPreset enumeration. The standard models have these presets included in whisper.cpp but for any other model you must specify the model-specific values.

For example, for the model "Distil Large V3", you need to use use:

```
        RuntimeOptions.Instance.SetUseDtwTimeStamps(true);
        RuntimeOptions.Instance.SetHeadsPreset(WhisperAlignmentHeadsPreset.Custom);
        RuntimeOptions.Instance.SetAlignmentHeads(
            Enumerable.Range(0, 20).Select(i => new WhisperAlignmentHead(1, i)).ToArray()
        );
```

This one seems simple (array where TextLayer is always 1, and Head is 0...19), but that isn't the case for every model. E.g. look at the presets in whisper.cpp for g_aheads_large_v2:

```
static const whisper_ahead g_aheads_large_v2[]  = { {10, 12}, {13, 17}, {16, 11}, {16, 12}, {16, 13}, {17, 15}, {17, 16}, {18, 4}, {18, 11}, {18, 19}, {19, 11}, {21, 2}, {21, 3}, {22, 3}, {22, 9}, {22, 12}, {23, 5}, {23, 7}, {23, 13}, {25, 5}, {26, 1}, {26, 12}, {27, 15} };
```
