### PR TITLE
Added Whisper Factory Options

### DIFF
--- a/Whisper.net/Ggml/GgmlType.cs
+++ b/Whisper.net/Ggml/GgmlType.cs
@@ -17,34 +17,3 @@ public enum GgmlType
     LargeV3,
     LargeV3Turbo
 }
-
-public enum WhisperAlignmentHeadsPreset
-{
-    None,
-    NTopMost,  // All heads from the N-top-most text-layers
-    Custom,
-    TinyEn,
-    Tiny,
-    BaseEn,
-    Base,
-    SmallEn,
-    Small,
-    MediumEn,
-    Medium,
-    LargeV1,
-    LargeV2,
-    LargeV3,
-    LargeV3Turbo
-}
-
-public class WhisperAlignmentHead
-{
-    public int TextLayer;
-    public int Head;
-
-    public WhisperAlignmentHead(int textLayer, int head)
-    {
-        TextLayer = textLayer;
-        Head = head;
-    }
-}

--- a/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
+++ b/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
@@ -27,7 +27,7 @@ internal static class ModelLoaderUtils
             WhisperAlignmentHeadsPreset.LargeV2 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V2,
             WhisperAlignmentHeadsPreset.LargeV3 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3,
             WhisperAlignmentHeadsPreset.LargeV3Turbo => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3_TURBO,
-            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "The given preset is not supported yet.")
         };
     }
 

--- a/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
+++ b/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
@@ -1,0 +1,64 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using System.Runtime.InteropServices;
+using Whisper.net.Native;
+using NativeHeadsPreset = Whisper.net.Native.WhisperAlignmentHeadsPreset;
+
+namespace Whisper.net.Internals.ModelLoader;
+
+internal static class ModelLoaderUtils
+{
+    public static NativeHeadsPreset Map(WhisperAlignmentHeadsPreset preset)
+    {
+        return preset switch
+        {
+            WhisperAlignmentHeadsPreset.None => NativeHeadsPreset.WHISPER_AHEADS_NONE,
+            WhisperAlignmentHeadsPreset.NTopMost => NativeHeadsPreset.WHISPER_AHEADS_N_TOP_MOST,
+            WhisperAlignmentHeadsPreset.Custom => NativeHeadsPreset.WHISPER_AHEADS_CUSTOM,
+            WhisperAlignmentHeadsPreset.TinyEn => NativeHeadsPreset.WHISPER_AHEADS_TINY_EN,
+            WhisperAlignmentHeadsPreset.Tiny => NativeHeadsPreset.WHISPER_AHEADS_TINY,
+            WhisperAlignmentHeadsPreset.Base => NativeHeadsPreset.WHISPER_AHEADS_BASE,
+            WhisperAlignmentHeadsPreset.BaseEn => NativeHeadsPreset.WHISPER_AHEADS_BASE_EN,
+            WhisperAlignmentHeadsPreset.Small => NativeHeadsPreset.WHISPER_AHEADS_SMALL,
+            WhisperAlignmentHeadsPreset.SmallEn => NativeHeadsPreset.WHISPER_AHEADS_SMALL_EN,
+            WhisperAlignmentHeadsPreset.Medium => NativeHeadsPreset.WHISPER_AHEADS_MEDIUM,
+            WhisperAlignmentHeadsPreset.MediumEn => NativeHeadsPreset.WHISPER_AHEADS_MEDIUM_EN,
+            WhisperAlignmentHeadsPreset.LargeV1 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V1,
+            WhisperAlignmentHeadsPreset.LargeV2 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V2,
+            WhisperAlignmentHeadsPreset.LargeV3 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3,
+            WhisperAlignmentHeadsPreset.LargeV3Turbo => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3_TURBO,
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, null)
+        };
+    }
+
+    public static WhisperAheads GetWhisperAlignmentHeads(WhisperAlignmentHead[]? alignmentHeads, out GCHandle? aHeadsHandle)
+    {
+        if (alignmentHeads == null || alignmentHeads.Length == 0)
+        {
+            aHeadsHandle = null;
+            return default;
+        }
+
+        var nHeads = alignmentHeads.Length;
+        var aHeads = new int[nHeads * 2];
+
+        aHeadsHandle = GCHandle.Alloc(aHeads, GCHandleType.Pinned);
+
+        for (var i = 0; i < nHeads; i++)
+        {
+            aHeads[i * 2] = alignmentHeads![i].TextLayer;
+            aHeads[i * 2 + 1] = alignmentHeads[i].Head;
+        }
+
+        return new WhisperAheads()
+        {
+            NHeads = (UIntPtr)nHeads,
+            Heads = aHeadsHandle.Value.AddrOfPinnedObject()
+        };
+    }
+
+    public static byte AsByte(this bool value)
+    {
+        return value ? (byte)1 : (byte)0;
+    }
+}

--- a/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
+++ b/Whisper.net/Internals/ModelLoader/ModelLoaderUtils.cs
@@ -27,7 +27,7 @@ internal static class ModelLoaderUtils
             WhisperAlignmentHeadsPreset.LargeV2 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V2,
             WhisperAlignmentHeadsPreset.LargeV3 => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3,
             WhisperAlignmentHeadsPreset.LargeV3Turbo => NativeHeadsPreset.WHISPER_AHEADS_LARGE_V3_TURBO,
-            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "The given preset is not supported yet.")
+            _ => throw new NotSupportedException($"The preset value: {preset} is not supported yet.")
         };
     }
 

--- a/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
+++ b/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
@@ -30,8 +30,6 @@ internal sealed class WhisperProcessorModelFileLoader : IWhisperProcessorModelLo
 
     public IntPtr LoadNativeContext(INativeWhisper nativeWhisper)
     {
-        ModelLoaderUtils.GetWhisperAlignmentHeads(options.CustomAlignmentHeads, out var aheadsHandle);
-
         return nativeWhisper.Whisper_Init_From_File_With_Params_No_State(pathModel,
            new WhisperContextParams()
            {

--- a/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
+++ b/Whisper.net/Internals/ModelLoader/WhisperProcessorModelFileLoader.cs
@@ -2,67 +2,47 @@
 
 using System.Runtime.InteropServices;
 using Whisper.net.Internals.Native;
-using Whisper.net.LibraryLoader;
 using Whisper.net.Native;
 
 namespace Whisper.net.Internals.ModelLoader;
 
-internal sealed class WhisperProcessorModelFileLoader(string pathModel) : IWhisperProcessorModelLoader
+internal sealed class WhisperProcessorModelFileLoader : IWhisperProcessorModelLoader
 {
-    private GCHandle aheadsHandle;
+    private readonly string pathModel;
+    private readonly WhisperFactoryOptions options;
+    private readonly WhisperAheads aHeads;
+    private readonly GCHandle? aheadsHandle;
+
+    public WhisperProcessorModelFileLoader(string pathModel, WhisperFactoryOptions options)
+    {
+        this.pathModel = pathModel;
+        this.options = options;
+        aHeads = ModelLoaderUtils.GetWhisperAlignmentHeads(options.CustomAlignmentHeads, out aheadsHandle);
+    }
 
     public void Dispose()
     {
-        if (aheadsHandle.IsAllocated)
+        if (aheadsHandle.HasValue)
         {
-            aheadsHandle.Free();
+            aheadsHandle.Value.Free();
         }
-    }
-
-    public static WhisperAheads GetWhisperAlignmentHeads(Ggml.WhisperAlignmentHead[]? alignmentHeads, ref GCHandle aHeadsHandle)
-    {
-        var aHeadsPtr = IntPtr.Zero;
-        var nHeads = alignmentHeads?.Length ?? 0;
-
-        if (nHeads > 0)
-        {
-            var aHeads = new int[nHeads * 2];
-            if (aHeadsHandle.IsAllocated)
-            {
-                aHeadsHandle.Free();
-            }
-            aHeadsHandle = GCHandle.Alloc(aHeads, GCHandleType.Pinned);
-            aHeadsPtr = aHeadsHandle.AddrOfPinnedObject();
-
-            for (var i = 0; i < nHeads; i++)
-            {
-                aHeads[i * 2] = alignmentHeads![i].TextLayer;
-                aHeads[i * 2 + 1] = alignmentHeads[i].Head;
-            }
-        }
-
-        return new WhisperAheads()
-        { 
-            NHeads = (nuint)nHeads,
-            Heads = aHeadsPtr
-        };
     }
 
     public IntPtr LoadNativeContext(INativeWhisper nativeWhisper)
     {
-        var aHeads = GetWhisperAlignmentHeads(RuntimeOptions.Instance.CustomAlignmentHeads, ref aheadsHandle);
+        ModelLoaderUtils.GetWhisperAlignmentHeads(options.CustomAlignmentHeads, out var aheadsHandle);
 
         return nativeWhisper.Whisper_Init_From_File_With_Params_No_State(pathModel,
            new WhisperContextParams()
            {
-               UseGpu = RuntimeOptions.Instance.UseGpu ? (byte)1 : (byte)0,
-               FlashAttention = RuntimeOptions.Instance.UseFlashAttention ? (byte)1 : (byte)0,
-               GpuDevice = RuntimeOptions.Instance.GpuDevice,
-               DtwTokenLevelTimestamp = RuntimeOptions.Instance.UseDtwTimeStamps ? (byte)1 : (byte)0,
-               HeadsPreset = (WhisperAlignmentHeadsPreset)RuntimeOptions.Instance.HeadsPreset,
-               DtwNTop = -1,
+               UseGpu = options.UseGpu.AsByte(),
+               FlashAttention = options.UseFlashAttention.AsByte(),
+               GpuDevice = options.GpuDevice,
+               DtwTokenLevelTimestamp = options.UseDtwTimeStamps.AsByte(),
+               HeadsPreset = ModelLoaderUtils.Map(options.HeadsPreset),
+               DtwNTop = options.DtwNTop,
                WhisperAheads = aHeads,
-               Dtw_mem_size = 1024 * 1024 * 128,
+               Dtw_mem_size = new UIntPtr(options.DtwMemSize)
            });
     }
 }

--- a/Whisper.net/Internals/Native/Data.cs
+++ b/Whisper.net/Internals/Native/Data.cs
@@ -80,7 +80,7 @@ internal struct WhisperAhead
 [StructLayout(LayoutKind.Sequential)]
 internal struct WhisperAheads
 {
-    public nuint NHeads;
+    public UIntPtr NHeads;
     public IntPtr Heads;
 }
 
@@ -94,7 +94,7 @@ internal struct WhisperContextParams
     public WhisperAlignmentHeadsPreset HeadsPreset;
     public int DtwNTop;
     public WhisperAheads WhisperAheads;
-    public nuint Dtw_mem_size;
+    public UIntPtr Dtw_mem_size;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -235,9 +235,9 @@ internal struct WhisperFullParams
 
     public IntPtr WhisperGrammarElement;
 
-    public nuint NGrammarRules;
+    public UIntPtr NGrammarRules;
 
-    public nuint StartGrammarRule;
+    public UIntPtr StartGrammarRule;
 
     public float GrammarPenalty;
 }

--- a/Whisper.net/LibraryLoader/RuntimeOptions.cs
+++ b/Whisper.net/LibraryLoader/RuntimeOptions.cs
@@ -1,7 +1,5 @@
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 
-using Whisper.net.Ggml;
-
 namespace Whisper.net.LibraryLoader;
 
 public class RuntimeOptions
@@ -9,12 +7,7 @@ public class RuntimeOptions
     private static readonly List<RuntimeLibrary> defaultRuntimeOrder = [RuntimeLibrary.Cuda, RuntimeLibrary.Vulkan, RuntimeLibrary.CoreML, RuntimeLibrary.OpenVino, RuntimeLibrary.Cpu, RuntimeLibrary.CpuNoAvx];
     internal bool BypassLoading { get; private set; }
     internal string? LibraryPath { get; private set; }
-    internal bool UseGpu { get; private set; }
-    internal bool UseFlashAttention { get; private set; }
-    internal bool UseDtwTimeStamps { get; private set; }
-    internal WhisperAlignmentHeadsPreset HeadsPreset { get; private set; }
-    internal WhisperAlignmentHead[]? CustomAlignmentHeads { get; private set; }
-    internal int GpuDevice { get; private set; }
+
     internal List<RuntimeLibrary> RuntimeLibraryOrder { get; private set; }
     internal RuntimeLibrary? LoadedLibrary { get; private set; }
 
@@ -24,13 +17,7 @@ public class RuntimeOptions
     {
         BypassLoading = false;
         LibraryPath = null;
-        UseGpu = true;
-        UseFlashAttention = false;
-        UseDtwTimeStamps = false;
-        HeadsPreset = WhisperAlignmentHeadsPreset.None;
-        CustomAlignmentHeads = null;
         RuntimeLibraryOrder = defaultRuntimeOrder;
-        GpuDevice = 0;
     }
 
     /// <summary>
@@ -56,39 +43,6 @@ public class RuntimeOptions
     }
 
     /// <summary>
-    /// Sets whether to use the GPU for processing.
-    /// </summary>
-    /// <remarks>
-    /// By default, it is true.
-    /// </remarks>
-    public void SetUseGpu(bool useGpu)
-    {
-        UseGpu = useGpu;
-    }
-
-    /// <summary>
-    /// Sets whether to use the FlashAttention for processing.
-    /// </summary>
-    /// <remarks>
-    /// By default, it is false.
-    /// </remarks>
-    public void SetUseFlashAttention(bool useFlashAttention)
-    {
-        UseFlashAttention = useFlashAttention;
-    }
-
-    /// <summary>
-    /// Sets the GPU device to use for processing.
-    /// </summary>
-    /// <remarks>
-    /// By default, it is 0.
-    /// </remarks>
-    public void SetGpuDevice(int device)
-    {
-        GpuDevice = device;
-    }
-
-    /// <summary>
     /// Sets the order of the runtime libraries to use for processing.
     /// </summary>
     /// <remarks>
@@ -108,52 +62,12 @@ public class RuntimeOptions
     }
 
     /// <summary>
-    /// Sets whether to use DTW timestamps.
-    /// </summary>
-    /// <remarks>
-    /// By default, it is false.
-    /// </remarks>
-    public void SetUseDtwTimeStamps(bool useDtw)
-    {
-        UseDtwTimeStamps = useDtw;
-    }
-
-    /// <summary>
-    /// Sets heads preset for DTW.
-    /// </summary>
-    /// <remarks>
-    /// By default, it is WhisperAlignmentHeadsPreset.None (0).
-    /// </remarks>
-    public void SetHeadsPreset(WhisperAlignmentHeadsPreset headsPreset)
-    {
-        HeadsPreset = headsPreset;
-    }
-
-    /// <summary>
-    /// Sets custom attention heads array for DTW. 
-    /// </summary>
-    /// <remarks>
-    /// By default, it is null. Required when using DTW with models which don't have a matching WhisperAlignmentHeadsPreset.
-    /// </remarks>
-    public void SetAlignmentHeads(WhisperAlignmentHead[]? alignmentHeads)
-    {
-        CustomAlignmentHeads = alignmentHeads;
-    }
-
-    /// <summary>
     /// Resets the runtime options to their default values.
     /// </summary>
     public void Reset()
     {
         BypassLoading = false;
         LibraryPath = null;
-        UseGpu = true;
-        UseFlashAttention = false;
-        UseDtwTimeStamps = false;
-        HeadsPreset = WhisperAlignmentHeadsPreset.None;
-        CustomAlignmentHeads = null;
         RuntimeLibraryOrder = defaultRuntimeOrder;
-        GpuDevice = 0;
     }
-
 }

--- a/Whisper.net/WhisperAlignmentHeads.cs
+++ b/Whisper.net/WhisperAlignmentHeads.cs
@@ -1,0 +1,72 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+namespace Whisper.net;
+public enum WhisperAlignmentHeadsPreset
+{
+    /// <summary>
+    /// No alignment heads.
+    /// </summary>
+    None,
+    /// <summary>
+    /// All heads from the N-top-most text-layers
+    /// </summary>
+    NTopMost,
+    /// <summary>
+    /// Custom alignment heads, provided by <see cref="WhisperFactoryOptions.CustomAlignmentHeads" />
+    /// </summary>
+    Custom,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.TinyEn"/>
+    /// </summary>
+    TinyEn,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.Tiny"/>
+    /// </summary>
+    Tiny,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.BaseEn"/>
+    /// </summary>
+    BaseEn,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.Base"/>
+    /// </summary>
+    Base,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.SmallEn"/>
+    /// </summary>
+    SmallEn,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.Small"/>
+    /// </summary>
+    Small,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.Medium"/>
+    /// </summary>
+    MediumEn,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.MediumEn"/>
+    /// </summary>
+    Medium,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.LargeV1"/>
+    /// </summary>
+    LargeV1,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.LargeV2"/>
+    /// </summary>
+    LargeV2,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.LargeV3"/>
+    /// </summary>
+    LargeV3,
+    /// <summary>
+    /// Alignment heads for the model <see cref="Ggml.GgmlType.LargeV3Turbo"/>
+    /// </summary>
+    LargeV3Turbo
+}
+
+public readonly struct WhisperAlignmentHead(int textLayer, int head)
+{
+    public int TextLayer { get; } = textLayer;
+    public int Head { get; } = head;
+}

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -89,6 +89,19 @@ public sealed class WhisperFactory : IDisposable
     }
 
     /// <summary>
+    /// Creates a factory that uses the ggml model from a buffer in order to create <seealso cref="WhisperProcessorBuilder"/>.
+    /// </summary>
+    /// <param name="path">The path to the model.</param>
+    /// <returns>An instance to the same builder.</returns>
+    /// <remarks>
+    /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
+    /// </remarks>
+    public static WhisperFactory FromPath(string path)
+    {
+        return FromPath(path, WhisperFactoryOptions.Default);
+    }
+
+    /// <summary>
     /// Creates a factory that uses the ggml model from a path in order to create <seealso cref="WhisperProcessorBuilder"/>.
     /// </summary>
     /// <param name="path">The path to the model.</param>
@@ -97,9 +110,22 @@ public sealed class WhisperFactory : IDisposable
     /// <remarks>
     /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
     /// </remarks>
-    public static WhisperFactory FromPath(string path, WhisperFactoryOptions options = default)
+    public static WhisperFactory FromPath(string path, WhisperFactoryOptions options)
     {
         return new WhisperFactory(new WhisperProcessorModelFileLoader(path, options), options.DelayInitialization);
+    }
+
+    /// <summary>
+    /// Creates a factory that uses the ggml model from a buffer in order to create <seealso cref="WhisperProcessorBuilder"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer with the model.</param>
+    /// <returns>An instance to the same builder.</returns>
+    /// <remarks>
+    /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
+    /// </remarks>
+    public static WhisperFactory FromBuffer(byte[] buffer)
+    {
+        return FromBuffer(buffer, WhisperFactoryOptions.Default);
     }
 
     /// <summary>
@@ -111,7 +137,7 @@ public sealed class WhisperFactory : IDisposable
     /// <remarks>
     /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
     /// </remarks>
-    public static WhisperFactory FromBuffer(byte[] buffer, WhisperFactoryOptions options = default)
+    public static WhisperFactory FromBuffer(byte[] buffer, WhisperFactoryOptions options)
     {
         return new WhisperFactory(new WhisperProcessorModelBufferLoader(buffer, options), options.DelayInitialization);
     }

--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -92,28 +92,28 @@ public sealed class WhisperFactory : IDisposable
     /// Creates a factory that uses the ggml model from a path in order to create <seealso cref="WhisperProcessorBuilder"/>.
     /// </summary>
     /// <param name="path">The path to the model.</param>
-    /// <param name="delayInitialization">A value indicating if the model should be loaded right away or during the first <see cref="CreateBuilder"/> call.</param>
+    /// <param name="options">The options for the factory and the loading of the model.</param>
     /// <returns>An instance to the same builder.</returns>
     /// <remarks>
     /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
     /// </remarks>
-    public static WhisperFactory FromPath(string path, bool delayInitialization = false)
+    public static WhisperFactory FromPath(string path, WhisperFactoryOptions options = default)
     {
-        return new WhisperFactory(new WhisperProcessorModelFileLoader(path), delayInitialization);
+        return new WhisperFactory(new WhisperProcessorModelFileLoader(path, options), options.DelayInitialization);
     }
 
     /// <summary>
     /// Creates a factory that uses the ggml model from a buffer in order to create <seealso cref="WhisperProcessorBuilder"/>.
     /// </summary>
     /// <param name="buffer">The buffer with the model.</param>
-    /// <param name="delayInitialization">A value indicating if the model should be loaded right away or during the first <see cref="CreateBuilder"/> call.</param>
+    /// <param name="options">Thhe options for the factory and the loading of the model.</param>
     /// <returns>An instance to the same builder.</returns>
     /// <remarks>
     /// If you don't know where to find a ggml model, you can use <seealso cref="Ggml.WhisperGgmlDownloader"/> which is downloading a model from huggingface.co.
     /// </remarks>
-    public static WhisperFactory FromBuffer(byte[] buffer, bool delayInitialization = false)
+    public static WhisperFactory FromBuffer(byte[] buffer, WhisperFactoryOptions options = default)
     {
-        return new WhisperFactory(new WhisperProcessorModelBufferLoader(buffer), delayInitialization);
+        return new WhisperFactory(new WhisperProcessorModelBufferLoader(buffer, options), options.DelayInitialization);
     }
 
     /// <summary>
@@ -124,10 +124,14 @@ public sealed class WhisperFactory : IDisposable
     /// <exception cref="WhisperModelLoadException">Throws if the model couldn't be loaded.</exception>
     public WhisperProcessorBuilder CreateBuilder()
     {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(wasDisposed, this);
+#else
         if (wasDisposed)
         {
             throw new ObjectDisposedException(nameof(WhisperFactory));
         }
+#endif
 
         var context = contextLazy.Value;
         if (context == IntPtr.Zero)

--- a/Whisper.net/WhisperFactoryOptions.cs
+++ b/Whisper.net/WhisperFactoryOptions.cs
@@ -1,0 +1,79 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+namespace Whisper.net;
+
+public struct WhisperFactoryOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to use GPU for processing.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is true.
+    /// </remarks>
+    public bool UseGpu { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use FlashAttention.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is false.
+    /// </remarks>
+    public bool UseFlashAttention { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use Dynamic Time Warping (DTW) time stamps.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is false.
+    /// </remarks>
+    public bool UseDtwTimeStamps { get; set; }
+
+    /// <summary>
+    /// Gets or sets the alignment heads preset for DTW.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is <see cref="WhisperAlignmentHeadsPreset.None"/>.
+    /// </remarks>
+    public WhisperAlignmentHeadsPreset HeadsPreset { get; set; } = WhisperAlignmentHeadsPreset.None;
+
+    /// <summary>
+    /// Gets or sets the custom alignment heads for DTW.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is null. Required when using DTW with models which don't have a matching <see cref="WhisperAlignmentHeadsPreset"/>.
+    /// </remarks>
+    public WhisperAlignmentHead[]? CustomAlignmentHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the GPU device to use for processing.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is 0.
+    /// </remarks>
+    public int GpuDevice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the DTW memory.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is 128 MB.
+    /// </remarks>
+    public uint DtwMemSize { get; set; } = 1024 * 1024 * 128;
+
+    /// <summary>
+    /// Gets or sets the N-top for DTW.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is -1.
+    /// </remarks>
+    public int DtwNTop { get; set; } = -1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to delay initialization of the Whisper context to the first call of <see cref="WhisperFactory.CreateBuilder"/>.
+    /// </summary>
+    /// <remarks>
+    /// By default, it is false and the model is loaded right away.
+    /// </remarks>
+    public bool DelayInitialization { get; set; }
+
+}

--- a/Whisper.net/WhisperFactoryOptions.cs
+++ b/Whisper.net/WhisperFactoryOptions.cs
@@ -4,13 +4,28 @@ namespace Whisper.net;
 
 public struct WhisperFactoryOptions
 {
+    public static WhisperFactoryOptions Default => new WhisperFactoryOptions();
+
+    public WhisperFactoryOptions()
+    {
+        // Default values
+        UseGpu = true;
+        UseFlashAttention = false;
+        UseDtwTimeStamps = false;
+        HeadsPreset = WhisperAlignmentHeadsPreset.None;
+        GpuDevice = 0;
+        DtwMemSize = 1024 * 1024 * 128;
+        DtwNTop = -1;
+        DelayInitialization = false;
+    }
+
     /// <summary>
     /// Gets or sets a value indicating whether to use GPU for processing.
     /// </summary>
     /// <remarks>
     /// By default, it is true.
     /// </remarks>
-    public bool UseGpu { get; set; } = true;
+    public bool UseGpu { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to use FlashAttention.
@@ -34,7 +49,7 @@ public struct WhisperFactoryOptions
     /// <remarks>
     /// By default, it is <see cref="WhisperAlignmentHeadsPreset.None"/>.
     /// </remarks>
-    public WhisperAlignmentHeadsPreset HeadsPreset { get; set; } = WhisperAlignmentHeadsPreset.None;
+    public WhisperAlignmentHeadsPreset HeadsPreset { get; set; }
 
     /// <summary>
     /// Gets or sets the custom alignment heads for DTW.
@@ -58,7 +73,7 @@ public struct WhisperFactoryOptions
     /// <remarks>
     /// By default, it is 128 MB.
     /// </remarks>
-    public uint DtwMemSize { get; set; } = 1024 * 1024 * 128;
+    public uint DtwMemSize { get; set; }
 
     /// <summary>
     /// Gets or sets the N-top for DTW.
@@ -66,7 +81,7 @@ public struct WhisperFactoryOptions
     /// <remarks>
     /// By default, it is -1.
     /// </remarks>
-    public int DtwNTop { get; set; } = -1;
+    public int DtwNTop { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to delay initialization of the Whisper context to the first call of <see cref="WhisperFactory.CreateBuilder"/>.


### PR DESCRIPTION
As the options for creating a WhisperFactory were growing, took the initiative to migrate some of the options that are reusable to WhisperFactoryOptions and removing them from RuntimeOptions.

Now, RuntimeOptions remains only for Library loading (whisper.cpp Runtime) and any other options like GPU device, DTW options, etc. can be defined for each factory independent on the library itself.