### PR TITLE
Reverted auto-commit for FluentAssertion bump by dependabot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="FluentAssertions" Version="8.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <!-- Tests -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />


### PR DESCRIPTION
Fluent Assertion changed their licensing method. It will be removed in future work, but for now, keeping the old Apache2 version.

Even if the usage will be for non-commercial purposes in this OS library, I do not indorse open-source software that change their license for newer versions.