### PR TITLE
Fix ConsoleLogging log level handling

### DIFF
--- a/Whisper.net/Logger/LogProvider.cs
+++ b/Whisper.net/Logger/LogProvider.cs
@@ -19,7 +19,7 @@ public static class LogProvider
         return new WhisperLogger((level, message) =>
         {
             // Higher values are less severe
-            if (level < minLevel)
+            if (level <= minLevel)
             {
                 Console.WriteLine($"[{level}] {message}");
             }


### PR DESCRIPTION
This only logs INFO or higher when it is executed.
```
LogProvider.AddConsoleLogging(WhisperLogLevel.Debug);
```

I thought the expected behavior was to also output DEBUG, so I modified the condition.
