### PR TITLE
Preparing 1.8.1

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -33,7 +33,7 @@ jobs:
 
    windows:
       uses: ./.github/workflows/windows-native-build.yml
-      
+
    windows-no-avx:
       uses: ./.github/workflows/windows-noavx-native-build.yml
 
@@ -58,7 +58,7 @@ jobs:
 
    windows-openvino:
       uses: ./.github/workflows/windows-openvino-native-build.yml
-      
+
    linux-cuda:
       if: ${{ inputs.BuildCuda == 'true' }}
       uses: ./.github/workflows/linux-cuda-native-build.yml
@@ -76,6 +76,11 @@ jobs:
          - windows
          - wasm
          - linux
+         - windows-vulkan
+         - linux-vulkan
+         - windows-openvino
+         - linux-openvino
+         - macos-coreml
       uses: ./.github/workflows/dotnet.yml
       secrets: inherit
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -87,7 +87,6 @@ jobs:
          - linux-vulkan
          - windows-openvino
          - linux-openvino
-         - macos-coreml
       uses: ./.github/workflows/dotnet.yml
       secrets: inherit
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -69,6 +69,13 @@ jobs:
    macos-coreml:
       uses: ./.github/workflows/macos-coreml-native-build.yml
 
+   dotnet-noavx:
+     needs:
+       - windows-no-avx
+       - linux-no-avx
+     uses: ./.github/workflows/dotnet-noavx.yml
+     secrets: inherit
+
    dotnet-build:
       needs:
          - android

--- a/.github/workflows/dotnet-noavx.yml
+++ b/.github/workflows/dotnet-noavx.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./Whisper.net.sln
 
+      - name: Run Dependency Checker
+        run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj CpuNoAvx
+
       - name: Build
         run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
 
@@ -88,7 +91,7 @@ jobs:
         run: dotnet restore ./Whisper.net.sln
 
       - name: Run Dependency Checker
-        run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
+        run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj CpuNoAvx
 
       - name: Build
         run: dotnet build ./Whisper.net.sln --no-restore -warnaserror

--- a/.github/workflows/dotnet-noavx.yml
+++ b/.github/workflows/dotnet-noavx.yml
@@ -15,6 +15,7 @@ on:
 env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   USE_WHISPER_NOAVX_TESTS: true
+  VSTEST_CONNECTION_TIMEOUT : 600
 
 jobs:
 
@@ -63,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()    # run this step even if previous step failed
         with:
-          name: test-results-windows
+          name: test-results-windows-noavx
           path: ./**/*.trx
           retention-days: 7
 
@@ -112,7 +113,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()    # run this step even if previous step failed
         with:
-          name: test-results-linux
+          name: test-results-linux-noavx
           path: ./**/*.trx
           retention-days: 7
 

--- a/.github/workflows/dotnet-noavx.yml
+++ b/.github/workflows/dotnet-noavx.yml
@@ -1,0 +1,115 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: Dotnet NoAvx Build and Test
+
+permissions:
+  contents: read
+  checks: write
+  security-events: write
+
+on:
+  workflow_call:
+
+
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  USE_WHISPER_NOAVX_TESTS: true
+
+jobs:
+
+  dotnet-noavx-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Download Artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: runtimes
+
+      - name: Restore dependencies
+        run: dotnet restore ./Whisper.net.sln
+
+      - name: Build
+        run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
+
+      - name: Test
+        run: |
+          dotnet test ./Whisper.net.sln --no-build --logger "trx"
+
+      - name: Test Reporter
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Whisper.net Windows Test Results
+          path: ./**/*.trx
+          reporter: dotnet-trx
+
+      - name: Upload trx files
+        uses: actions/upload-artifact@v4
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: test-results-windows
+          path: ./**/*.trx
+          retention-days: 7
+
+  dotnet-noavx-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Download Artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: runtimes
+
+      - name: Restore dependencies
+        run: dotnet restore ./Whisper.net.sln
+
+      - name: Run Dependency Checker
+        run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
+
+      - name: Build
+        run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
+
+      - name: Test
+        run: |
+          dotnet test ./Whisper.net.sln --no-build --logger "trx"
+
+      - name: Test Reporter
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Whisper.net Linux Test Results
+          path: ./**/*.trx
+          reporter: dotnet-trx
+
+      - name: Upload trx files
+        uses: actions/upload-artifact@v4
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: test-results-linux
+          path: ./**/*.trx
+          retention-days: 7
+

--- a/Whisper.net.Demo/Whisper.net.Demo.csproj
+++ b/Whisper.net.Demo/Whisper.net.Demo.csproj
@@ -1,9 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<Import Condition="'$(EnableCoreML)' != 'true'" Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
-  <Import Condition="'$(EnableCoreML)' == 'true'" Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
-	<PropertyGroup>
+	<Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="'$(EnableCoreML)' == 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+  <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''"
+          Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+
+  <PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>13</LangVersion>
 	</PropertyGroup>
 

--- a/Whisper.net.sln
+++ b/Whisper.net.sln
@@ -38,6 +38,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "github", "github", "{5C8656
 		.github\workflows\windows-noavx-native-build.yml = .github\workflows\windows-noavx-native-build.yml
 		.github\workflows\windows-openvino-native-build.yml = .github\workflows\windows-openvino-native-build.yml
 		.github\workflows\windows-vulkan-native-build.yml = .github\workflows\windows-vulkan-native-build.yml
+		.github\workflows\dotnet-noavx.yml = .github\workflows\dotnet-noavx.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{52C6C243-3BD7-41CF-A0B0-1DE31AC2C884}"

--- a/Whisper.net/Whisper.net.csproj
+++ b/Whisper.net/Whisper.net.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>13</LangVersion>
-    <Version>1.8.0-preview1</Version>
+    <Version>1.8.1-preview1</Version>
     <Authors>Sandro Hanea</Authors>
     <Description>Cross-platform dotnet bindings for Whisper.</Description>
     <PackageProjectUrl>https://github.com/sandrohanea/whisper.net</PackageProjectUrl>
@@ -27,7 +27,7 @@
   <!--<PropertyGroup>
     <USE_WHISPER_MAUI>TRUE</USE_WHISPER_MAUI>
   </PropertyGroup>-->
- 
+
   <PropertyGroup Condition="$(USE_WHISPER_MAUI) != ''">
     <TargetFrameworks>
       net8.0;net9.0;netstandard2.0;net8.0-ios;net8.0-tvos;net8.0-maccatalyst;net8.0-android;net9.0-ios;net9.0-tvos;net9.0-maccatalyst;net9.0-android
@@ -40,7 +40,7 @@
     <PackageReference Include="System.IO.Compression" />
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <InternalsVisibleTo Include="Whisper.net.Maui.Tests" />
     <InternalsVisibleTo Include="Whisper.net.Tests" />

--- a/examples/BlazorApp/BlazorApp.Client/BlazorApp.Client.csproj
+++ b/examples/BlazorApp/BlazorApp.Client/BlazorApp.Client.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/ContinuousRecognition/ContinuousRecognition.csproj
+++ b/examples/ContinuousRecognition/ContinuousRecognition.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/CoreML/CoreML.csproj
+++ b/examples/CoreML/CoreML.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
-    <PackageReference Include="Whisper.net.Runtime.CoreML" Version="1.7.4" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
+    <PackageReference Include="Whisper.net.Runtime.CoreML" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/CoreML/Program.cs
+++ b/examples/CoreML/Program.cs
@@ -28,12 +28,12 @@ public class Program
         if (!Directory.Exists(coreMlModelcName))
         {
             // Note: The modelc directory needs to be extracted at the same level as the "ggml-base.bin" file (and the current executable).
-            await WhisperGgmlDownloader.GetEncoderCoreMLModelAsync(ggmlType)
+            await WhisperGgmlDownloader.Default.GetEncoderCoreMLModelAsync(ggmlType)
                                        .ExtractToPath(".");
         }
 
         // Optional logging from the native library
-        
+
         using var whisperLogger = LogProvider.AddLogger((level, message) =>
         {
             Console.Write($"{level}: {message}");

--- a/examples/Diarization/Diarization.csproj
+++ b/examples/Diarization/Diarization.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/LowAllocationStringPooling/LowAllocationStringPooling.csproj
+++ b/examples/LowAllocationStringPooling/LowAllocationStringPooling.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/MultiRuntime/MultiRuntime.csproj
+++ b/examples/MultiRuntime/MultiRuntime.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime.Cuda" Version="1.7.4" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime.Cuda" Version="1.8.0" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/NAudioMp3/NAudioMp3.csproj
+++ b/examples/NAudioMp3/NAudioMp3.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NAudioResampleWav/NAudioResampleWav.csproj
+++ b/examples/NAudioResampleWav/NAudioResampleWav.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NvidiaCuda/NvidiaCuda.csproj
+++ b/examples/NvidiaCuda/NvidiaCuda.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
-    <PackageReference Include="Whisper.net.Runtime.Cuda" Version="1.7.4" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
+    <PackageReference Include="Whisper.net.Runtime.Cuda" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/OpenVinoExample/OpenVinoExample.csproj
+++ b/examples/OpenVinoExample/OpenVinoExample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime.OpenVino" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime.OpenVino" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/OpenVinoExample/Program.cs
+++ b/examples/OpenVinoExample/Program.cs
@@ -31,7 +31,7 @@ public class Program
         if (!Directory.Exists(encoderDirectoryName))
         {
             // Note: The encoder directory needs to be extracted
-            await WhisperGgmlDownloader.GetEncoderOpenVinoModelAsync(ggmlType)
+            await WhisperGgmlDownloader.Default.GetEncoderOpenVinoModelAsync(ggmlType)
                                        .ExtractToPath(encoderDirectoryName);
         }
 
@@ -39,7 +39,7 @@ public class Program
         using var whisperFactory = WhisperFactory.FromPath(modelFileName);
 
         // We need to get the path to the xml encoder manifest file
-        var xmlEncoderManifest = Path.Combine(encoderDirectoryName, WhisperGgmlDownloader.GetOpenVinoManifestFileName(ggmlType));
+        var xmlEncoderManifest = Path.Combine(encoderDirectoryName, WhisperGgmlDownloader.Default.GetOpenVinoManifestFileName(ggmlType));
 
         // This section creates the processor object which is used to process the audio file, it uses language `auto` to detect the language of the audio file.
         using var processor = whisperFactory.CreateBuilder()

--- a/examples/ParallelExecution/ParallelExecution.csproj
+++ b/examples/ParallelExecution/ParallelExecution.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/Simple/Simple.csproj
+++ b/examples/Simple/Simple.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/SimpleSync/SimpleSync.csproj
+++ b/examples/SimpleSync/SimpleSync.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Vulkan/Vulkan.csproj
+++ b/examples/Vulkan/Vulkan.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net.Runtime.Vulkan" Version="1.7.4" />
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime.Vulkan" Version="1.8.0" />
+    <PackageReference Include="Whisper.net" Version="1.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ To install Whisper.net with all the available runtimes, run the following comman
 Or add a package reference in your `.csproj` file:
 
 ```
-    <PackageReference Include="Whisper.net.AllRuntimes" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.AllRuntimes" Version="1.8.1" />
 ```
 
 `Whisper.net` is the main package that contains the core functionality but does not include any runtimes. `Whisper.net.AllRuntimes` includes all available runtimes for Whisper.net.
@@ -31,10 +31,10 @@ Or add a package reference in your `.csproj` file:
 To install a specific runtime, you can install them individually and combine them as needed. For example, to install the CPU runtime, add the following package references:
 
 ```
-    <PackageReference Include="Whisper.net" Version="1.7.4" />
+    <PackageReference Include="Whisper.net" Version="1.8.1" />
 ```
 ```
-    <PackageReference Include="Whisper.net.Runtime" Version="1.7.4" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.8.1" />
 ```
 
 ## GPT for Whisper
@@ -66,7 +66,7 @@ The default runtime that uses the CPU for inference. It is available on all plat
  - Linux: `libstdc++6`, `glibc 2.31`
  - macOS: TBD
  - For x86/x64 platforms, the CPU must support AVX, AVX2, FMA and F16C instructions. If your CPU does not support these instructions, you'll need to use the `Whisper.net.Runtime.NoAvx` runtime instead.
-  
+
 #### Supported Platforms
 
 - Windows x86, x64, ARM64
@@ -87,7 +87,7 @@ For CPUs that do not support AVX instructions.
  - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2019 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
  - Linux: `libstdc++6`, `glibc 2.31`
  - macOS: TBD
- 
+
 #### Supported Platforms
 
 - Windows x86, x64, ARM64
@@ -100,7 +100,7 @@ Contains the native whisper.cpp library with NVidia CUDA support enabled.
 #### Examples
 
  - [CUDA usage example](https://github.com/sandrohanea/whisper.net/tree/main/examples/NvidiaCuda)
- 
+
 #### Pre-requisites
 
 - Everything from Whisper.net.Runtime pre-requisites
@@ -177,7 +177,7 @@ The following order of priority will be used by default:
 To change the order or force a specific runtime, set the `RuntimeLibraryOrder` on the `RuntimeOptions`:
 
 ```csharp
-RuntimeOptions.RuntimeLibraryOrder = 
+RuntimeOptions.RuntimeLibraryOrder =
 [
     RuntimeLibrary.CoreML,
     RuntimeLibrary.OpenVino,

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -1,22 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <!-- Whisper.net.Runtime cannot be referenced in MAUI ios dependency project that is only targetting net8.0 or net9.0 as it will copy the runtimes for linux, mac and windows and will cause the build to fail. -->
-  <Import Condition="$(USE_WHISPER_COREML_TESTS) != ''"
-          Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
 
   <Import Condition="$(USE_WHISPER_NOAVX_TESTS) != ''"
           Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
 
-  <Import Condition="$(USE_WHISPER_OPENVINO_TESTS) == ''"
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
+      AND $(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
-  
-  <Import Condition="$(USE_WHISPER_VULKAN_TESTS) == ''"
+
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
+      AND $(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
 
   <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
-      AND $(USE_WHISPER_NOAVX_TESTS) == ''
-      AND $(USE_WHISPER_COREML_TESTS) == ''
-      AND $(USE_WHISPER_OPENVINO_TESTS) == ''
-      AND $(USE_WHISPER_VULKAN_TESTS) == ''"
+      AND $(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
 
 	<PropertyGroup>

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- Whisper.net.Runtime cannot be referenced in MAUI ios dependency project that is only targetting net8.0 or net9.0 as it will copy the runtimes for linux, mac and windows and will cause the build to fail. -->
-	<Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -13,7 +17,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    
+
 		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -38,5 +42,5 @@
       <LogicalName>(Filename)%(Extension)</LogicalName>
     </None>
 	</ItemGroup>
-  
+
 </Project>

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -1,10 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- Whisper.net.Runtime cannot be referenced in MAUI ios dependency project that is only targetting net8.0 or net9.0 as it will copy the runtimes for linux, mac and windows and will cause the build to fail. -->
-  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
-  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
-  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
-  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
-  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''" Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="$(USE_WHISPER_COREML_TESTS) != ''"
+          Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) != ''"
+          Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+
+  <Import Condition="$(USE_WHISPER_OPENVINO_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
+  
+  <Import Condition="$(USE_WHISPER_VULKAN_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
+
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
+      AND $(USE_WHISPER_NOAVX_TESTS) == ''
+      AND $(USE_WHISPER_COREML_TESTS) == ''
+      AND $(USE_WHISPER_OPENVINO_TESTS) == ''
+      AND $(USE_WHISPER_VULKAN_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/tools/WhisperNetDependencyChecker/Program.cs
+++ b/tools/WhisperNetDependencyChecker/Program.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Whisper.net.LibraryLoader;
 using WhisperNetDependencyChecker.DependencyWalker;
 
-var library = RuntimeLibrary.Cpu;
+var library = args.Length > 0 ? Enum.Parse<RuntimeLibrary>(args[0]) : RuntimeLibrary.Cpu;
 
 var dependencyProvider = new NativeDependencyWalker();
 

--- a/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
+++ b/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
@@ -1,6 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
-  
+  <Import Condition="$(USE_WHISPER_COREML_TESTS) != ''"
+          Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) != ''"
+          Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+
+  <Import Condition="$(USE_WHISPER_OPENVINO_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
+
+  <Import Condition="$(USE_WHISPER_VULKAN_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
+
+
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''
+      AND $(USE_WHISPER_COREML_TESTS) == ''
+      AND $(USE_WHISPER_OPENVINO_TESTS) == ''
+      AND $(USE_WHISPER_VULKAN_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>

--- a/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
+++ b/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
@@ -1,21 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Condition="$(USE_WHISPER_COREML_TESTS) != ''"
-          Project="../../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
 
   <Import Condition="$(USE_WHISPER_NOAVX_TESTS) != ''"
           Project="../../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
 
-  <Import Condition="$(USE_WHISPER_OPENVINO_TESTS) == ''"
-          Project="../../runtimes/Whisper.net.Runtime.OpenVino/Whisper.net.Runtime.OpenVino.targets" />
-
-  <Import Condition="$(USE_WHISPER_VULKAN_TESTS) == ''"
-          Project="../../runtimes/Whisper.net.Runtime.Vulkan/Whisper.net.Runtime.Vulkan.targets" />
-
-
-  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''
-      AND $(USE_WHISPER_COREML_TESTS) == ''
-      AND $(USE_WHISPER_OPENVINO_TESTS) == ''
-      AND $(USE_WHISPER_VULKAN_TESTS) == ''"
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
 
   <PropertyGroup>

--- a/windows-scripts.ps1
+++ b/windows-scripts.ps1
@@ -48,10 +48,10 @@ function BuildWindows() {
 
     $buildDirectory = "build/win-$Arch"
     $options = @(
-        "-S", ".", 
+        "-S", ".",
         "-DGGML_NATIVE=OFF"
     )
-    
+    $runtimePath = "./runtimes/Whisper.net.Runtime"
 
     $avxOptions = @("-DGGML_AVX=ON", "-DGGML_AVX2=ON", "-DGGML_FMA=ON", "-DGGML_F16C=ON")
 
@@ -79,8 +79,6 @@ function BuildWindows() {
             $options += "-DGGML_BMI2=OFF";
         }
     }
-    
-    $runtimePath = "./runtimes/Whisper.net.Runtime"
 
     if ($Cuda) {
         $options += "-DGGML_CUDA=1"
@@ -94,7 +92,7 @@ function BuildWindows() {
         $buildDirectory += "-vulkan"
         $runtimePath += ".Vulkan"
     }
-    
+
     if ($OpenVino) {
         $options += "-DWHISPER_OPENVINO=1"
         $buildDirectory += "-openvino"
@@ -181,7 +179,7 @@ function PackAll([Parameter(Mandatory = $true)] [string]$Version) {
     if (-not(Test-Path "nupkgs")) {
         New-Item -ItemType Directory -Force -Path "nupkgs"
     }
-    
+
     nuget pack runtimes/Whisper.net.Runtime.nuspec -Version $Version -OutputDirectory ./nupkgs
     dotnet pack Whisper.net/Whisper.net.csproj -p:Version=$Version -o ./nupkgs -c Release
     nuget pack runtimes/Whisper.net.Runtime.CoreML.nuspec -Version $Version -OutputDirectory ./nupkgs


### PR DESCRIPTION
Updated all example projects to use Whisper.net and relevant runtime packages version 1.8.0. Adjusted code to use the new `WhisperGgmlDownloader.Default` API for model downloads and manifest file retrieval. Incremented the library version to 1.8.1-preview1 in the main project.