### PR TITLE
Add ISpeechToTextClient implementation support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <ItemGroup>
     <PackageVersion Include="ELFSharp" Version="2.17.3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0-preview.1.25204.8" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.4.0-preview.1.25207.5" />
     <PackageVersion Include="System.Memory" Version="4.6.2" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   <ItemGroup>
     <PackageVersion Include="ELFSharp" Version="2.17.3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0-preview.1.25204.8" />
     <PackageVersion Include="System.Memory" Version="4.6.2" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
@@ -11,7 +12,7 @@
     <!-- Tests -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Whisper.net.AllRuntimes" Version="1.7.4" />
+    <PackageVersion Include="Whisper.net.AllRuntimes" Version="1.8.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="10.0.0-prerelease.25174.1" />

--- a/Whisper.net.Demo/Program.cs
+++ b/Whisper.net.Demo/Program.cs
@@ -73,7 +73,7 @@ async Task FullDetection(Options opt)
     using var processor = builder.Build();
 
     using var fileStream = File.OpenRead(opt.FileName);
-
+    Console.WriteLine($"Using {nameof(WhisperProcessor)}:\n");
     await foreach (var segment in processor.ProcessAsync(fileStream, CancellationToken.None))
     {
         Console.WriteLine($"New Segment: {segment.Start} ==> {segment.End} : {segment.Text}");
@@ -95,6 +95,7 @@ async Task FullDetectionSpeechToText(Options opt)
 
     using var fileStream = File.OpenRead(opt.FileName);
 
+    Console.WriteLine($"\nUsing {nameof(ISpeechToTextClient)}:\n");
     await foreach (var segment in speechToTextClient.GetStreamingTextAsync(fileStream, options, CancellationToken.None))
     {
         Console.WriteLine($"New Segment: {segment.StartTime} ==> {segment.EndTime} : {segment.Text}");

--- a/Whisper.net.Demo/Whisper.net.Demo.csproj
+++ b/Whisper.net.Demo/Whisper.net.Demo.csproj
@@ -1,10 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
-	<Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
-          Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
-  <Import Condition="'$(EnableCoreML)' == 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
-          Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
-  <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''"
-          Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''" Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="'$(EnableCoreML)' == 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''" Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+  <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''" Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
 
   <PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -14,6 +11,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CommandLineParser" />
+	  <PackageReference Include="Whisper.net.Allruntimes" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Whisper.net.Demo/Whisper.net.Demo.csproj
+++ b/Whisper.net.Demo/Whisper.net.Demo.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''" Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
-  <Import Condition="'$(EnableCoreML)' == 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''" Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
-  <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''" Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+	<Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="'$(EnableCoreML)' == 'true' AND $(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
+  <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''"
+          Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
 
   <PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -11,7 +14,6 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CommandLineParser" />
-	  <PackageReference Include="Whisper.net.Allruntimes" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Whisper.net.Demo/Whisper.net.Demo.sln
+++ b/Whisper.net.Demo/Whisper.net.Demo.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Whisper.net.Demo", "Whisper.net.Demo.csproj", "{C98BD896-29FA-3E24-8D52-DE5AE94A47CC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C98BD896-29FA-3E24-8D52-DE5AE94A47CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C98BD896-29FA-3E24-8D52-DE5AE94A47CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C98BD896-29FA-3E24-8D52-DE5AE94A47CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C98BD896-29FA-3E24-8D52-DE5AE94A47CC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {85152ABC-2DDD-454F-865E-8AB9B1C3908E}
+	EndGlobalSection
+EndGlobal

--- a/Whisper.net/Internals/Native/INativeCuda.cs
+++ b/Whisper.net/Internals/Native/INativeCuda.cs
@@ -9,5 +9,4 @@ internal interface INativeCuda : IDisposable
     public delegate int cudaGetDeviceCount(out int count);
 
     cudaGetDeviceCount CudaGetDeviceCount { get; }
-
 }

--- a/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
@@ -250,7 +250,6 @@ public static class NativeLibraryLoader
                     WhisperLogger.Log(WhisperLogLevel.Debug, $"Runtime directory for {library} not found in {runtimePath}");
                 }
             }
-
         }
     }
 
@@ -272,5 +271,4 @@ public static class NativeLibraryLoader
         }
 #endif
     }
-
 }

--- a/Whisper.net/LibraryLoader/UniversalLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/UniversalLibraryLoader.cs
@@ -1,7 +1,6 @@
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 
 #if !NETSTANDARD
-using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/Whisper.net/SpeechToTextClient/SpeechToTextOptionsExtensions.cs
+++ b/Whisper.net/SpeechToTextClient/SpeechToTextOptionsExtensions.cs
@@ -8,15 +8,77 @@ namespace Whisper.net;
 
 public static class SpeechToTextOptionsExtensions
 {
-    internal const string BeamSearchSamplingStrategyKey = "BeamSearchSamplingStrategy";
-    internal const string AudioContextSizeKey = "AudioContextSize";
+    private const string BeamSearchSamplingStrategyKey = "BeamSearchSamplingStrategy";
+    private const string AudioContextSizeKey = "AudioContextSize";
+    private const string DurationKey = "Duration";
+    private const string EncoderBeginHandlerKey = "EncoderBeginHandler";
+    private const string EntropyThresholdKey = "EntropyThreshold";
+    private const string GreedySamplingStrategyKey = "GreedySamplingStrategy";
+    private const string LanguageKey = "Language";
+    private const string LanguageDetectionKey = "LanguageDetection";
+    private const string LengthPenaltyKey = "LengthPenalty";
+    private const string LogProbThresholdKey = "LogProbThreshold";
+    private const string MaxInitialTsKey = "MaxInitialTs";
+    private const string MaxSegmentLengthKey = "MaxSegmentLength";
+    private const string MaxLastTextTokensKey = "MaxLastTextTokens";
+    private const string MaxTokensPerSegmentKey = "MaxTokensPerSegment";
+    private const string NoContextKey = "NoContext";
+    private const string NoSpeechThresholdKey = "NoSpeechThreshold";
+    private const string OffsetKey = "Offset";
+    private const string OpenVinoEncoderPathKey = "OpenVinoEncoderPath";
+    private const string OpenVinoDeviceKey = "OpenVinoDevice";
+    private const string OpenVinoCachePathKey = "OpenVinoCachePath";
+    private const string SuppressBlankKey = "SuppressBlank";
+    private const string StringPoolKey = "StringPool";
+    private const string PrintProgressKey = "PrintProgress";
+    private const string PrintTimestampsKey = "PrintTimestamps";
+    private const string PrintSpecialTokensKey = "PrintSpecialTokens";
+    private const string PrintResultsKey = "PrintResults";
+    private const string ProbabilitiesKey = "Probabilities";
+    private const string ProgressHandlerKey = "ProgressHandler";
+    private const string SegmentEventHandlerKey = "SegmentEventHandler";
+    private const string TemperatureKey = "Temperature";
+    private const string TemperatureIncKey = "TemperatureInc";
+    private const string ThreadsKey = "Threads";
+    private const string TokenTimestampsKey = "TokenTimestamps";
+    private const string TokenTimestampsSumThresholdKey = "TokenTimestampsSumThreshold";
+    private const string TokenTimestampsThresholdKey = "TokenTimestampsThreshold";
 
+    /// <summary>
+    /// Configures the processor with the language to be used for detection.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="language">The language (2 letters) to be used.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is "en".
+    /// Example: "en", "ro"
+    /// </remarks>
     public static SpeechToTextOptions WithLanguage(this SpeechToTextOptions options, string language)
     {
         options.SpeechLanguage = language;
         return options;
     }
 
+    /// <summary>
+    /// Configures the processor to translate the text to English.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor will just transcribe it.
+    /// </remarks>
+    public static SpeechToTextOptions WithTranslate(this SpeechToTextOptions options)
+    {
+        options.TextLanguage = "English";
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use the Beam Search Sampling Strategy.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
     public static SpeechToTextOptions WithBeamSearchSamplingStrategy(this SpeechToTextOptions options)
     {
         options.AdditionalProperties ??= [];
@@ -25,10 +87,727 @@ public static class SpeechToTextOptionsExtensions
         return options;
     }
 
+    /// <summary>
+    ///  [EXPERIMENTAL] Configures the processor to override the audio context size.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="audioContextSize">Audio context size to be overridden</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Quality might be degraded while performance might be improved.
+    /// </remarks>
     public static SpeechToTextOptions WithAudioContextSize(this SpeechToTextOptions options, int audioContextSize)
     {
         options.AdditionalProperties ??= [];
         options.AdditionalProperties[AudioContextSizeKey] = audioContextSize;
         return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the duration in the audio to which it processes.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="duration">Duration in the audio.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processing is happening until the end.
+    /// </remarks>
+    public static SpeechToTextOptions WithDuration(this SpeechToTextOptions options, TimeSpan duration)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[DurationKey] = duration;
+        return options;
+    }
+
+    /// <summary>
+    /// Adds a <see cref="OnEncoderBeginEventHandler"/> which will be called when the encoder begins processing.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="handler">The event handler to be added.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithEncoderBeginHandler(this SpeechToTextOptions options, OnEncoderBeginEventHandler handler)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[EncoderBeginHandlerKey] = handler;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with an entropy threshold for decoder fallback.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threshold">The entropy threshold.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is 2.4f.
+    /// </remarks>
+    public static SpeechToTextOptions WithEntropyThreshold(this SpeechToTextOptions options, float threshold)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[EntropyThresholdKey] = threshold;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use the Greedy Sampling strategy.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithGreedySamplingStrategy(this SpeechToTextOptions options)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[GreedySamplingStrategyKey] = true;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the language to be used for detection.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="language">The language (2 letters) to be used.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is "en".
+    /// Example: "en", "ro"
+    /// </remarks>
+    public static SpeechToTextOptions WithWhisperLanguage(this SpeechToTextOptions options, string language)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[LanguageKey] = language;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to auto-detect the language based on initial samples.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="enableDetection">Whether to enable language detection.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Note: Processing time will slightly increase.
+    /// </remarks>
+    public static SpeechToTextOptions WithLanguageDetection(this SpeechToTextOptions options, bool enableDetection = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[LanguageDetectionKey] = enableDetection;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with a value indicating the length penalty (alpha).
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="penalty">The length penalty value.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor will use simple length normalization by default.
+    /// More information about the length penalty can be found here: https://arxiv.org/abs/1609.08144.
+    /// </remarks>
+    public static SpeechToTextOptions WithLengthPenalty(this SpeechToTextOptions options, float penalty)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[LengthPenaltyKey] = penalty;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with a average log probability threshold over sampled tokens.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threshold">The average log probability threshold.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is -1.0f.
+    /// </remarks>
+    public static SpeechToTextOptions WithLogProbThreshold(this SpeechToTextOptions options, float threshold)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[LogProbThresholdKey] = threshold;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with a value indicating that the initial timestamp cannot be later than this.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="maxInitialTs">The initial max timestamp.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, default value is: 1f.
+    /// </remarks>
+    public static SpeechToTextOptions WithMaxInitialTs(this SpeechToTextOptions options, float maxInitialTs)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[MaxInitialTsKey] = maxInitialTs;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the maximum segment length in characters.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="maxLength">The maximum segment length in characters.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithMaxSegmentLength(this SpeechToTextOptions options, int maxLength)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[MaxSegmentLengthKey] = maxLength;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the max number of tokens to be used from the previous text as prompt for the decoder.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="maxTokens">The max number of tokens to be used.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, a number of 16384 tokens is used.
+    /// </remarks>
+    public static SpeechToTextOptions WithMaxLastTextTokens(this SpeechToTextOptions options, int maxTokens)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[MaxLastTextTokensKey] = maxTokens;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the maximum number of tokens per segment.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="maxTokens">The maximum number of tokens per segment.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithMaxTokensPerSegment(this SpeechToTextOptions options, int maxTokens)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[MaxTokensPerSegmentKey] = maxTokens;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to not use past transformation (if any) as the initial prompt for a newer processing.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="noContext">Whether to disable context.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor use part transformations as initial prompt for newer processing.
+    /// </remarks>
+    public static SpeechToTextOptions WithNoContext(this SpeechToTextOptions options, bool noContext = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[NoContextKey] = noContext;
+        return options;
+    }
+
+    /// <summary>
+    /// [EXPERIMENTAL] Configures the processor with a no_speech probability.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threshold">The no_speech probability</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is 0.6f.
+    /// </remarks>
+    public static SpeechToTextOptions WithNoSpeechThreshold(this SpeechToTextOptions options, float threshold)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[NoSpeechThresholdKey] = threshold;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with the start time in the audio from which it starts the processing.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="offset">Offset in the audio.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processing is happening from the beginning.
+    /// </remarks>
+    public static SpeechToTextOptions WithOffset(this SpeechToTextOptions options, TimeSpan offset)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[OffsetKey] = offset;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use OpenVINO for the encoder part.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="encoderPath">Path to the OpenVINO encoder model.</param>
+    /// <param name="device">The device to use for OpenVINO.</param>
+    /// <param name="cachePath">Path to the OpenVINO cache directory.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithOpenVinoEncoder(this SpeechToTextOptions options, string? encoderPath, string? device = null, string? cachePath = null)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[OpenVinoEncoderPathKey] = encoderPath;
+        if (device != null)
+        {
+            options.AdditionalProperties[OpenVinoDeviceKey] = device;
+        }
+        if (cachePath != null)
+        {
+            options.AdditionalProperties[OpenVinoCachePathKey] = cachePath;
+        }
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to NOT suppress blank outputs.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, blanks are automatically suppressed.
+    /// </remarks>
+    public static SpeechToTextOptions WithoutSuppressBlank(this SpeechToTextOptions options)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[SuppressBlankKey] = false;
+        return options;
+    }
+
+    /// <summary>
+    /// Disables the string pooling.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// This will disable the pooling of strings that are generated (have effect only if <see cref="WithStringPool"/> was called).
+    /// </remarks>
+    public static SpeechToTextOptions WithoutStringPool(this SpeechToTextOptions options)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[StringPoolKey] = false;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to print progress information.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="printProgress">Whether to print progress information.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor will not print progress information.
+    /// </remarks>
+    public static SpeechToTextOptions WithPrintProgress(this SpeechToTextOptions options, bool printProgress = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[PrintProgressKey] = printProgress;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to print timestamps for each segment to stdout.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="printTimestamps">Whether to print timestamps.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// This option is available only if <see cref="WithPrintResults"/> is configured.
+    /// If not specified, the processor will print also timestamps.
+    /// </remarks>
+    public static SpeechToTextOptions WithPrintTimestamps(this SpeechToTextOptions options, bool printTimestamps = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[PrintTimestampsKey] = printTimestamps;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to print special tokens to stdout.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="printSpecialTokens">Whether to print special tokens.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// This option is available only if <see cref="WithPrintResults"/> is configured.
+    /// </remarks>
+    public static SpeechToTextOptions WithPrintSpecialTokens(this SpeechToTextOptions options, bool printSpecialTokens = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[PrintSpecialTokensKey] = printSpecialTokens;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to print results to stdout.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="printResults">Whether to print results.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor will not print results to stdout.
+    /// </remarks>
+    public static SpeechToTextOptions WithPrintResults(this SpeechToTextOptions options, bool printResults = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[PrintResultsKey] = printResults;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to return probabilities during segment decoding <see cref="SegmentData.MaxProbability"/>, <see cref="SegmentData.MinProbability"/> and <see cref="SegmentData.Probability"/>.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="enableProbabilities">Whether to enable probabilities.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithProbabilities(this SpeechToTextOptions options, bool enableProbabilities = true)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[ProbabilitiesKey] = enableProbabilities;
+        return options;
+    }
+
+    /// <summary>
+    /// Adds a <see cref="OnProgressHandler"/> which will be called to report progress.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="handler">The event handler to be added.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithProgressHandler(this SpeechToTextOptions options, OnProgressHandler handler)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[ProgressHandlerKey] = handler;
+        return options;
+    }
+
+    /// <summary>
+    /// Adds a <see cref="OnSegmentEventHandler"/> which will be called every time a new segment is detected.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="handler">The event handler to be added.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    public static SpeechToTextOptions WithSegmentEventHandler(this SpeechToTextOptions options, OnSegmentEventHandler handler)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[SegmentEventHandlerKey] = handler;
+        return options;
+    }
+
+    /// <summary>
+    /// Adds the functionality of pooling the strings that are generated reducing the number of allocations.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="stringPool">The string pool to use.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// When using this option designed for high-performance use-cases,
+    /// ensure that you're returning the <see cref="SegmentData"/> object back to the <see cref="WhisperProcessor"/>
+    /// using the method <see cref="WhisperProcessor.Return(SegmentData)"/>.
+    /// </remarks>
+    public static SpeechToTextOptions WithStringPool(this SpeechToTextOptions options, IStringPool stringPool)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[StringPoolKey] = stringPool;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with a temperature for sampling.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="temperature">The temperature value.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+    /// Default value is 0.0f.
+    /// </remarks>
+    public static SpeechToTextOptions WithTemperature(this SpeechToTextOptions options, float temperature)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[TemperatureKey] = temperature;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor with a temperature to increase when falling back.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="temperatureInc">The temperature to increase when falling back.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Falling back can happen when the decoding fails to meet either of the thresholds in: <see cref="WithEntropyThreshold"/>, <see cref="WithLogProbThreshold"/> or <see cref="WithNoSpeechThreshold"/>.
+    /// Default value is 0.2f.
+    /// </remarks>
+    public static SpeechToTextOptions WithTemperatureInc(this SpeechToTextOptions options, float temperatureInc)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[TemperatureIncKey] = temperatureInc;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use the specified number of threads.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threads">The number of threads to be used during encoding and decoding.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the same number as the hardware threads that the underlying hardware can support concurrently is used.
+    /// </remarks>
+    public static SpeechToTextOptions WithThreads(this SpeechToTextOptions options, int threads)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[ThreadsKey] = threads;
+        return options;
+    }
+
+    /// <summary>
+    /// [EXPERIMENTAL] Configures the processor to use token-level timestamps.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// If not specified, the processor will not use token timestamps.
+    /// </remarks>
+    public static SpeechToTextOptions WithTokenTimestamps(this SpeechToTextOptions options)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[TokenTimestampsKey] = true;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use the specified SUM probability threshold for token timestamps.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threshold">Probability SUM threshold to be used for token-level timestamps.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is 0.01f.
+    /// This option have effect only together with <see cref="WithTokenTimestamps"/>
+    /// </remarks>
+    public static SpeechToTextOptions WithTokenTimestampsSumThreshold(this SpeechToTextOptions options, float threshold)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[TokenTimestampsSumThresholdKey] = threshold;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the processor to use the specified probability threshold for token timestamps.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="threshold">Probability threshold to be used for token-level timestamps.</param>
+    /// <returns>The same options instance for chaining.</returns>
+    /// <remarks>
+    /// Default value is 0.01f.
+    /// This option have effect only together with <see cref="WithTokenTimestamps"/>
+    /// </remarks>
+    public static SpeechToTextOptions WithTokenTimestampsThreshold(this SpeechToTextOptions options, float threshold)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[TokenTimestampsThresholdKey] = threshold;
+        return options;
+    }
+
+    internal static WhisperProcessor BuildWhisperProcessor(this SpeechToTextOptions? options, WhisperFactory factory)
+    {
+        var processorBuilder = factory.CreateBuilder();
+
+        if (options is null)
+        {
+            return processorBuilder.Build();
+        }
+
+        if (!string.IsNullOrWhiteSpace(options?.SpeechLanguage))
+        {
+            processorBuilder.WithLanguage(options!.SpeechLanguage!);
+        }
+
+        if (GetAdditionalProperty<int>(AudioContextSizeKey, options!, out var audioContextSize))
+        {
+            processorBuilder.WithAudioContextSize(audioContextSize);
+        }
+
+        if (GetAdditionalProperty<bool>(BeamSearchSamplingStrategyKey, options!, out var beamSearchSamplingStrategy) && beamSearchSamplingStrategy)
+        {
+            processorBuilder.WithBeamSearchSamplingStrategy();
+        }
+
+        if (GetAdditionalProperty<TimeSpan>(DurationKey, options!, out var duration))
+        {
+            processorBuilder.WithDuration(duration);
+        }
+
+        if (GetAdditionalProperty<OnEncoderBeginEventHandler>(EncoderBeginHandlerKey, options!, out var encoderBeginHandler) && encoderBeginHandler != null)
+        {
+            processorBuilder.WithEncoderBeginHandler(encoderBeginHandler);
+        }
+
+        if (GetAdditionalProperty<float>(EntropyThresholdKey, options!, out var entropyThreshold))
+        {
+            processorBuilder.WithEntropyThreshold(entropyThreshold);
+        }
+
+        if (GetAdditionalProperty<bool>(GreedySamplingStrategyKey, options!, out var greedySamplingStrategy) && greedySamplingStrategy)
+        {
+            processorBuilder.WithGreedySamplingStrategy();
+        }
+
+        if (GetAdditionalProperty<string>(LanguageKey, options!, out var language) && !string.IsNullOrEmpty(language))
+        {
+            processorBuilder.WithLanguage(language);
+        }
+
+        if (GetAdditionalProperty<bool>(LanguageDetectionKey, options!, out var languageDetection) && languageDetection)
+        {
+            processorBuilder.WithLanguageDetection();
+        }
+
+        if (GetAdditionalProperty<float>(LengthPenaltyKey, options!, out var lengthPenalty))
+        {
+            processorBuilder.WithLengthPenalty(lengthPenalty);
+        }
+
+        if (GetAdditionalProperty<float>(LogProbThresholdKey, options!, out var logProbThreshold))
+        {
+            processorBuilder.WithLogProbThreshold(logProbThreshold);
+        }
+
+        if (GetAdditionalProperty<float>(MaxInitialTsKey, options!, out var maxInitialTs))
+        {
+            processorBuilder.WithMaxInitialTs(maxInitialTs);
+        }
+
+        if (GetAdditionalProperty<int>(MaxSegmentLengthKey, options!, out var maxSegmentLength))
+        {
+            processorBuilder.WithMaxSegmentLength(maxSegmentLength);
+        }
+
+        if (GetAdditionalProperty<int>(MaxLastTextTokensKey, options!, out var maxLastTextTokens))
+        {
+            processorBuilder.WithMaxLastTextTokens(maxLastTextTokens);
+        }
+
+        if (GetAdditionalProperty<int>(MaxTokensPerSegmentKey, options!, out var maxTokensPerSegment))
+        {
+            processorBuilder.WithMaxTokensPerSegment(maxTokensPerSegment);
+        }
+
+        if (GetAdditionalProperty<bool>(NoContextKey, options!, out var noContext) && noContext)
+        {
+            processorBuilder.WithNoContext();
+        }
+
+        if (GetAdditionalProperty<float>(NoSpeechThresholdKey, options!, out var noSpeechThreshold))
+        {
+            processorBuilder.WithNoSpeechThreshold(noSpeechThreshold);
+        }
+
+        if (GetAdditionalProperty<TimeSpan>(OffsetKey, options!, out var offset))
+        {
+            processorBuilder.WithOffset(offset);
+        }
+
+        if (GetAdditionalProperty<string>(OpenVinoEncoderPathKey, options!, out var openVinoEncoderPath))
+        {
+            GetAdditionalProperty<string>(OpenVinoDeviceKey, options!, out var openVinoDevice);
+            GetAdditionalProperty<string>(OpenVinoCachePathKey, options!, out var openVinoCachePath);
+            processorBuilder.WithOpenVinoEncoder(openVinoEncoderPath, openVinoDevice, openVinoCachePath);
+        }
+
+        if (GetAdditionalProperty<bool>(SuppressBlankKey, options!, out var suppressBlank) && !suppressBlank)
+        {
+            processorBuilder.WithoutSuppressBlank();
+        }
+
+        if (GetAdditionalProperty<bool>(StringPoolKey, options!, out var useStringPool) && !useStringPool)
+        {
+            processorBuilder.WithoutStringPool();
+        }
+
+        if (GetAdditionalProperty<bool>(PrintProgressKey, options!, out var printProgress) && printProgress)
+        {
+            processorBuilder.WithPrintProgress();
+        }
+
+        if (GetAdditionalProperty<bool>(PrintTimestampsKey, options!, out var printTimestamps) && printTimestamps)
+        {
+            processorBuilder.WithPrintTimestamps();
+        }
+
+        if (GetAdditionalProperty<bool>(PrintSpecialTokensKey, options!, out var printSpecialTokens) && printSpecialTokens)
+        {
+            processorBuilder.WithPrintSpecialTokens();
+        }
+
+        if (GetAdditionalProperty<bool>(PrintResultsKey, options!, out var printResults) && printResults)
+        {
+            processorBuilder.WithPrintResults();
+        }
+
+        if (GetAdditionalProperty<bool>(ProbabilitiesKey, options!, out var probabilities) && probabilities)
+        {
+            processorBuilder.WithProbabilities();
+        }
+
+        if (GetAdditionalProperty<OnProgressHandler>(ProgressHandlerKey, options!, out var progressHandler) && progressHandler != null)
+        {
+            processorBuilder.WithProgressHandler(progressHandler);
+        }
+
+        if (GetAdditionalProperty<OnSegmentEventHandler>(SegmentEventHandlerKey, options!, out var segmentEventHandler) && segmentEventHandler != null)
+        {
+            processorBuilder.WithSegmentEventHandler(segmentEventHandler);
+        }
+
+        if (GetAdditionalProperty<IStringPool>(StringPoolKey, options!, out var stringPool) && stringPool != null)
+        {
+            processorBuilder.WithStringPool(stringPool);
+        }
+
+        if (GetAdditionalProperty<float>(TemperatureKey, options!, out var temperature))
+        {
+            processorBuilder.WithTemperature(temperature);
+        }
+
+        if (GetAdditionalProperty<float>(TemperatureIncKey, options!, out var temperatureInc))
+        {
+            processorBuilder.WithTemperatureInc(temperatureInc);
+        }
+
+        if (GetAdditionalProperty<int>(ThreadsKey, options!, out var threads))
+        {
+            processorBuilder.WithThreads(threads);
+        }
+
+        if (GetAdditionalProperty<bool>(TokenTimestampsKey, options!, out var tokenTimestamps) && tokenTimestamps)
+        {
+            processorBuilder.WithTokenTimestamps();
+        }
+
+        if (GetAdditionalProperty<float>(TokenTimestampsSumThresholdKey, options!, out var tokenTimestampsSumThreshold))
+        {
+            processorBuilder.WithTokenTimestampsSumThreshold(tokenTimestampsSumThreshold);
+        }
+
+        if (GetAdditionalProperty<float>(TokenTimestampsThresholdKey, options!, out var tokenTimestampsThreshold))
+        {
+            processorBuilder.WithTokenTimestampsThreshold(tokenTimestampsThreshold);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options?.TextLanguage))
+        {
+            processorBuilder.WithTranslate();
+        }
+
+        return processorBuilder.Build();
+    }
+
+    private static bool GetAdditionalProperty<T>(string propertyName, SpeechToTextOptions options, out T? value)
+    {
+        if (options.AdditionalProperties?.TryGetValue(propertyName, out value) ?? false)
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
     }
 }

--- a/Whisper.net/SpeechToTextClient/SpeechToTextOptionsExtensions.cs
+++ b/Whisper.net/SpeechToTextClient/SpeechToTextOptionsExtensions.cs
@@ -1,0 +1,34 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Microsoft.Extensions.AI;
+
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Whisper.net;
+
+public static class SpeechToTextOptionsExtensions
+{
+    internal const string BeamSearchSamplingStrategyKey = "BeamSearchSamplingStrategy";
+    internal const string AudioContextSizeKey = "AudioContextSize";
+
+    public static SpeechToTextOptions WithLanguage(this SpeechToTextOptions options, string language)
+    {
+        options.SpeechLanguage = language;
+        return options;
+    }
+
+    public static SpeechToTextOptions WithBeamSearchSamplingStrategy(this SpeechToTextOptions options)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[BeamSearchSamplingStrategyKey] = true;
+
+        return options;
+    }
+
+    public static SpeechToTextOptions WithAudioContextSize(this SpeechToTextOptions options, int audioContextSize)
+    {
+        options.AdditionalProperties ??= [];
+        options.AdditionalProperties[AudioContextSizeKey] = audioContextSize;
+        return options;
+    }
+}

--- a/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
+++ b/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
@@ -108,16 +108,15 @@ public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
                 processorBuilder.WithLanguage(options!.SpeechLanguage!);
             }
 
-            if (GetAdditionalProperty<int>("AudioContextSize", options!, out var audioContextSize))
+            if (GetAdditionalProperty<int>(SpeechToTextOptionsExtensions.AudioContextSizeKey, options!, out var audioContextSize))
             {
                 processorBuilder.WithAudioContextSize(audioContextSize);
             }
 
-            if (GetAdditionalProperty<bool>("BeamSearchSamplingStrategy", options!, out var beamSearchSamplingStrategy) && beamSearchSamplingStrategy)
+            if (GetAdditionalProperty<bool>(SpeechToTextOptionsExtensions.BeamSearchSamplingStrategyKey, options!, out var beamSearchSamplingStrategy) && beamSearchSamplingStrategy)
             {
                 processorBuilder.WithBeamSearchSamplingStrategy();
             }
-
 
             /*
             processorBuilder.WithDuration(options?.Duration ?? TimeSpan.MinValue);

--- a/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
+++ b/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
@@ -1,0 +1,176 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.AI;
+
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Whisper.net;
+
+public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
+{
+    private readonly WhisperFactory _factory;
+    private WhisperProcessor? _processor;
+
+    public WhisperSpeechToTextClient(string modelFileName)
+    {
+        this._factory = WhisperFactory.FromPath(modelFileName);
+    }
+
+    public void Dispose()
+    {
+        if (this._processor != null)
+        {
+            this._processor.Dispose();
+        }
+
+        if (this._factory != null)
+        {
+            this._factory.Dispose();
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async IAsyncEnumerable<SpeechToTextResponseUpdate> GetStreamingTextAsync(Stream audioSpeechStream, SpeechToTextOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (audioSpeechStream is null)
+        {
+            throw new ArgumentNullException(nameof(audioSpeechStream));
+        }
+
+        PrepareProcessor(options);
+
+        var responseId = Guid.NewGuid().ToString();
+        await foreach (var segment in this._processor!.ProcessAsync(audioSpeechStream, cancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            yield return new SpeechToTextResponseUpdate(segment.Text)
+            {
+                ResponseId = responseId,
+                Kind = SpeechToTextResponseUpdateKind.TextUpdating,
+                RawRepresentation = segment,
+                StartTime = segment.Start,
+                EndTime = segment.End
+            };
+        }
+    }
+
+    public async Task<SpeechToTextResponse> GetTextAsync(Stream audioSpeechStream, SpeechToTextOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        SpeechToTextResponse response = new();
+        PrepareProcessor(options);
+
+        StringBuilder fullTranscription = new();
+        List<SegmentData> segments = [];
+
+        await foreach (var segment in this._processor!.ProcessAsync(audioSpeechStream, cancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            response.StartTime ??= segment.Start;
+            response.EndTime = segment.End;
+
+            segments.Add(segment);
+            fullTranscription.Append(segment.Text);
+        }
+
+        response.ResponseId = Guid.NewGuid().ToString();
+        response.RawRepresentation = segments;
+        response.Contents = [new TextContent(fullTranscription.ToString())];
+
+        return response;
+    }
+
+    private void PrepareProcessor(SpeechToTextOptions? options)
+    {
+        if (this._processor is not null)
+        {
+            return;
+        }
+        
+        var processorBuilder = this._factory.CreateBuilder();
+        if (options is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(options?.SpeechLanguage))
+            {
+                processorBuilder.WithLanguage(options!.SpeechLanguage!);
+            }
+
+            if (GetAdditionalProperty<int>("AudioContextSize", options!, out var audioContextSize))
+            {
+                processorBuilder.WithAudioContextSize(audioContextSize);
+            }
+
+            if (GetAdditionalProperty<bool>("BeamSearchSamplingStrategy", options!, out var beamSearchSamplingStrategy) && beamSearchSamplingStrategy)
+            {
+                processorBuilder.WithBeamSearchSamplingStrategy();
+            }
+
+
+            /*
+            processorBuilder.WithDuration(options?.Duration ?? TimeSpan.MinValue);
+            processorBuilder.WithEncoderBeginHandler(options?.EncoderBeginHandler);
+            processorBuilder.WithEntropyThreshold(options?.EntropyThreshold ?? 0.0f);
+
+            if (GetAdditionalProperty<bool>("GreedySamplingStrategy", options!, out var greedySamplingStrategy) && greedySamplingStrategy)
+            {
+                processorBuilder.WithGreedySamplingStrategy();
+            }
+
+            processorBuilder.WithLanguage(options?.Language ?? string.Empty);
+            processorBuilder.WithLanguageDetection(options?.LanguageDetection ?? false);
+            processorBuilder.WithLengthPenalty(options?.LengthPenalty ?? 0.0f);
+            processorBuilder.WithLogProbThreshold(options?.LogProbThreshold ?? 0.0f);
+            processorBuilder.WithMaxInitialTs(options?.MaxInitialTs ?? 0);
+            processorBuilder.WithMaxSegmentLength(options?.MaxSegmentLength ?? 0);
+            processorBuilder.WithMaxLastTextTokens(options?.MaxLastTextTokens ?? 0);
+            processorBuilder.WithMaxTokensPerSegment(options?.MaxTokensPerSegment ?? 0);
+            processorBuilder.WithNoContext(options?.NoContext ?? false);
+            processorBuilder.WithNoSpeechThreshold(options?.NoSpeechThreshold ?? 0.0f);
+            processorBuilder.WithOffset(options?.Offset ?? 0);
+            processorBuilder.WithOpenVinoEncoder(options?.OpenVinoEncoderPath, options?.OpenVinoDevice, options?.OpenVinoCachePath);
+            processorBuilder.WithoutSuppressBlank();
+            processorBuilder.WithoutStringPool();
+            processorBuilder.WithPrintProgress(options?.PrintProgress ?? false);
+            processorBuilder.WithPrintTimestamps(options?.PrintTimestamps ?? false);
+            processorBuilder.WithPrintSpecialTokens(options?.PrintSpecialTokens ?? false);
+            processorBuilder.WithPrintResults(options?.PrintResults ?? false);
+            processorBuilder.WithProbabilities(options?.Probabilities ?? false);
+            processorBuilder.WithProgressHandler(options?.ProgressHandler);
+            processorBuilder.WithSegmentEventHandler(options?.SegmentEventHandler);
+            processorBuilder.WithStringPool(options?.StringPool ?? string.Empty);
+            processorBuilder.WithTemperature(options?.Temperature ?? 0.0f);
+            processorBuilder.WithTemperatureInc(options?.TemperatureInc ?? 0.0f);
+            processorBuilder.WithThreads(options?.Threads ?? 0);
+            processorBuilder.WithTokenTimestamps();
+            processorBuilder.WithTokenTimestampsSumThreshold(options?.TokenTimestampsSumThreshold ?? 0.0f);
+            processorBuilder.WithTokenTimestampsThreshold(options?.TokenTimestampsThreshold ?? 0.0f);
+            */
+        }
+
+        this._processor = processorBuilder.Build();
+    }
+
+    private static bool GetAdditionalProperty<T>(string propertyName, SpeechToTextOptions options, out T? value)
+    {
+        if (options.AdditionalProperties?.TryGetValue(propertyName, out value) ?? false)
+        {
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
+++ b/Whisper.net/SpeechToTextClient/WhisperSpeechToTextClient.cs
@@ -8,27 +8,15 @@ using Microsoft.Extensions.AI;
 
 namespace Whisper.net;
 
-public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
+public sealed class WhisperSpeechToTextClient(string modelFileName) : ISpeechToTextClient
 {
-    private readonly WhisperFactory _factory;
+    private readonly WhisperFactory _factory = WhisperFactory.FromPath(modelFileName);
     private WhisperProcessor? _processor;
-
-    public WhisperSpeechToTextClient(string modelFileName)
-    {
-        this._factory = WhisperFactory.FromPath(modelFileName);
-    }
 
     public void Dispose()
     {
-        if (this._processor != null)
-        {
-            this._processor.Dispose();
-        }
-
-        if (this._factory != null)
-        {
-            this._factory.Dispose();
-        }
+        _processor?.Dispose();
+        _factory?.Dispose();
     }
 
     public object? GetService(Type serviceType, object? serviceKey = null)
@@ -43,10 +31,10 @@ public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
             throw new ArgumentNullException(nameof(audioSpeechStream));
         }
 
-        PrepareProcessor(options);
+        this._processor ??= options.BuildWhisperProcessor(_factory);
 
         var responseId = Guid.NewGuid().ToString();
-        await foreach (var segment in this._processor!.ProcessAsync(audioSpeechStream, cancellationToken))
+        await foreach (var segment in _processor!.ProcessAsync(audioSpeechStream, cancellationToken))
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -66,13 +54,19 @@ public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
 
     public async Task<SpeechToTextResponse> GetTextAsync(Stream audioSpeechStream, SpeechToTextOptions? options = null, CancellationToken cancellationToken = default)
     {
+        if (audioSpeechStream is null)
+        {
+            throw new ArgumentNullException(nameof(audioSpeechStream));
+        }
+
         SpeechToTextResponse response = new();
-        PrepareProcessor(options);
+
+        this._processor ??= options.BuildWhisperProcessor(_factory);
 
         StringBuilder fullTranscription = new();
         List<SegmentData> segments = [];
 
-        await foreach (var segment in this._processor!.ProcessAsync(audioSpeechStream, cancellationToken))
+        await foreach (var segment in _processor!.ProcessAsync(audioSpeechStream, cancellationToken))
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -91,85 +85,5 @@ public sealed class WhisperSpeechToTextClient : ISpeechToTextClient
         response.Contents = [new TextContent(fullTranscription.ToString())];
 
         return response;
-    }
-
-    private void PrepareProcessor(SpeechToTextOptions? options)
-    {
-        if (this._processor is not null)
-        {
-            return;
-        }
-        
-        var processorBuilder = this._factory.CreateBuilder();
-        if (options is not null)
-        {
-            if (!string.IsNullOrWhiteSpace(options?.SpeechLanguage))
-            {
-                processorBuilder.WithLanguage(options!.SpeechLanguage!);
-            }
-
-            if (GetAdditionalProperty<int>(SpeechToTextOptionsExtensions.AudioContextSizeKey, options!, out var audioContextSize))
-            {
-                processorBuilder.WithAudioContextSize(audioContextSize);
-            }
-
-            if (GetAdditionalProperty<bool>(SpeechToTextOptionsExtensions.BeamSearchSamplingStrategyKey, options!, out var beamSearchSamplingStrategy) && beamSearchSamplingStrategy)
-            {
-                processorBuilder.WithBeamSearchSamplingStrategy();
-            }
-
-            /*
-            processorBuilder.WithDuration(options?.Duration ?? TimeSpan.MinValue);
-            processorBuilder.WithEncoderBeginHandler(options?.EncoderBeginHandler);
-            processorBuilder.WithEntropyThreshold(options?.EntropyThreshold ?? 0.0f);
-
-            if (GetAdditionalProperty<bool>("GreedySamplingStrategy", options!, out var greedySamplingStrategy) && greedySamplingStrategy)
-            {
-                processorBuilder.WithGreedySamplingStrategy();
-            }
-
-            processorBuilder.WithLanguage(options?.Language ?? string.Empty);
-            processorBuilder.WithLanguageDetection(options?.LanguageDetection ?? false);
-            processorBuilder.WithLengthPenalty(options?.LengthPenalty ?? 0.0f);
-            processorBuilder.WithLogProbThreshold(options?.LogProbThreshold ?? 0.0f);
-            processorBuilder.WithMaxInitialTs(options?.MaxInitialTs ?? 0);
-            processorBuilder.WithMaxSegmentLength(options?.MaxSegmentLength ?? 0);
-            processorBuilder.WithMaxLastTextTokens(options?.MaxLastTextTokens ?? 0);
-            processorBuilder.WithMaxTokensPerSegment(options?.MaxTokensPerSegment ?? 0);
-            processorBuilder.WithNoContext(options?.NoContext ?? false);
-            processorBuilder.WithNoSpeechThreshold(options?.NoSpeechThreshold ?? 0.0f);
-            processorBuilder.WithOffset(options?.Offset ?? 0);
-            processorBuilder.WithOpenVinoEncoder(options?.OpenVinoEncoderPath, options?.OpenVinoDevice, options?.OpenVinoCachePath);
-            processorBuilder.WithoutSuppressBlank();
-            processorBuilder.WithoutStringPool();
-            processorBuilder.WithPrintProgress(options?.PrintProgress ?? false);
-            processorBuilder.WithPrintTimestamps(options?.PrintTimestamps ?? false);
-            processorBuilder.WithPrintSpecialTokens(options?.PrintSpecialTokens ?? false);
-            processorBuilder.WithPrintResults(options?.PrintResults ?? false);
-            processorBuilder.WithProbabilities(options?.Probabilities ?? false);
-            processorBuilder.WithProgressHandler(options?.ProgressHandler);
-            processorBuilder.WithSegmentEventHandler(options?.SegmentEventHandler);
-            processorBuilder.WithStringPool(options?.StringPool ?? string.Empty);
-            processorBuilder.WithTemperature(options?.Temperature ?? 0.0f);
-            processorBuilder.WithTemperatureInc(options?.TemperatureInc ?? 0.0f);
-            processorBuilder.WithThreads(options?.Threads ?? 0);
-            processorBuilder.WithTokenTimestamps();
-            processorBuilder.WithTokenTimestampsSumThreshold(options?.TokenTimestampsSumThreshold ?? 0.0f);
-            processorBuilder.WithTokenTimestampsThreshold(options?.TokenTimestampsThreshold ?? 0.0f);
-            */
-        }
-
-        this._processor = processorBuilder.Build();
-    }
-
-    private static bool GetAdditionalProperty<T>(string propertyName, SpeechToTextOptions options, out T? value)
-    {
-        if (options.AdditionalProperties?.TryGetValue(propertyName, out value) ?? false)
-        {
-            return true;
-        }
-
-        value = default;
-        return false;
     }
 }

--- a/Whisper.net/Whisper.net.csproj
+++ b/Whisper.net/Whisper.net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -44,6 +44,10 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Whisper.net.Maui.Tests" />
     <InternalsVisibleTo Include="Whisper.net.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Whisper.net/WhisperFactoryOptions.cs
+++ b/Whisper.net/WhisperFactoryOptions.cs
@@ -90,5 +90,4 @@ public struct WhisperFactoryOptions
     /// By default, it is false and the model is loaded right away.
     /// </remarks>
     public bool DelayInitialization { get; set; }
-
 }

--- a/nuget.config
+++ b/nuget.config
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
     <add key="public_nugget" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <!--<add key="Local Whisper" value="C:\Projects\sandrohanea\whisper.net\nupkgs" />-->
+    <add key="dotnet9-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
   </packageSources>
 
   <packageSourceMapping>

--- a/tests/Whisper.net.Tests/ProcessAsyncFunctionalTests.cs
+++ b/tests/Whisper.net.Tests/ProcessAsyncFunctionalTests.cs
@@ -155,7 +155,5 @@ public partial class ProcessAsyncFunctionalTests(TinyModelFixture model) : IClas
 
         Assert.True(segments1.SequenceEqual(segments2, new SegmentDataComparer()));
         Assert.True(segments2.SequenceEqual(segments3, new SegmentDataComparer()));
-
     }
-
 }

--- a/tests/Whisper.net.Tests/SegmentDataComparer.cs
+++ b/tests/Whisper.net.Tests/SegmentDataComparer.cs
@@ -19,5 +19,4 @@ public partial class ProcessAsyncFunctionalTests
             return obj.Text.GetHashCode();
         }
     }
-
 }

--- a/tests/Whisper.net.Tests/SpeechToText/SpeechToTextOptionsExtensionsTests.cs
+++ b/tests/Whisper.net.Tests/SpeechToText/SpeechToTextOptionsExtensionsTests.cs
@@ -1,0 +1,759 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Microsoft.Extensions.AI;
+using Xunit;
+
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Whisper.net.Tests;
+
+public class SpeechToTextOptionsExtensionsTests
+{
+    [Fact]
+    public void WithLanguage_SetsLanguageProperty()
+    {
+        // Arrange
+
+        var options = new SpeechToTextOptions();
+
+        var language = "en";
+
+        // Act
+        var result = options.WithLanguage(language);
+
+        // Assert
+        Assert.Equal(language, options.SpeechLanguage);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTranslate_SetsTextLanguageToEnglish()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithTranslate();
+
+        // Assert
+        Assert.Equal("English", options.TextLanguage);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithBeamSearchSamplingStrategy_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithBeamSearchSamplingStrategy();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("BeamSearchSamplingStrategy", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithAudioContextSize_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var audioContextSize = 42;
+
+        // Act
+        var result = options.WithAudioContextSize(audioContextSize);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("AudioContextSize", out var value));
+        Assert.Equal(audioContextSize, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithDuration_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var duration = TimeSpan.FromSeconds(10);
+
+        // Act
+        var result = options.WithDuration(duration);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Duration", out var value));
+        Assert.Equal(duration, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithEncoderBeginHandler_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        OnEncoderBeginEventHandler handler = (e) => true;
+
+        // Act
+        var result = options.WithEncoderBeginHandler(handler);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("EncoderBeginHandler", out var value));
+        Assert.Same(handler, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithEntropyThreshold_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threshold = 2.4f;
+
+        // Act
+        var result = options.WithEntropyThreshold(threshold);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("EntropyThreshold", out var value));
+        Assert.Equal(threshold, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithGreedySamplingStrategy_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithGreedySamplingStrategy();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("GreedySamplingStrategy", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithWhisperLanguage_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var language = "en";
+
+        // Act
+        var result = options.WithWhisperLanguage(language);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Language", out var value));
+        Assert.Equal(language, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithLanguageDetection_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithLanguageDetection();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("LanguageDetection", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithLanguageDetection_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithLanguageDetection(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("LanguageDetection", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithLengthPenalty_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var penalty = 0.5f;
+
+        // Act
+        var result = options.WithLengthPenalty(penalty);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("LengthPenalty", out var value));
+        Assert.Equal(penalty, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithLogProbThreshold_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threshold = -1.0f;
+
+        // Act
+        var result = options.WithLogProbThreshold(threshold);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("LogProbThreshold", out var value));
+        Assert.Equal(threshold, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithMaxInitialTs_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var maxInitialTs = 1.0f;
+
+        // Act
+        var result = options.WithMaxInitialTs(maxInitialTs);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("MaxInitialTs", out var value));
+        Assert.Equal(maxInitialTs, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithMaxSegmentLength_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var maxLength = 100;
+
+        // Act
+        var result = options.WithMaxSegmentLength(maxLength);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("MaxSegmentLength", out var value));
+        Assert.Equal(maxLength, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithMaxLastTextTokens_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var maxTokens = 16384;
+
+        // Act
+        var result = options.WithMaxLastTextTokens(maxTokens);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("MaxLastTextTokens", out var value));
+        Assert.Equal(maxTokens, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithMaxTokensPerSegment_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var maxTokens = 50;
+
+        // Act
+        var result = options.WithMaxTokensPerSegment(maxTokens);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("MaxTokensPerSegment", out var value));
+        Assert.Equal(maxTokens, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithNoContext_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithNoContext();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("NoContext", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithNoContext_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithNoContext(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("NoContext", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithNoSpeechThreshold_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threshold = 0.6f;
+
+        // Act
+        var result = options.WithNoSpeechThreshold(threshold);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("NoSpeechThreshold", out var value));
+        Assert.Equal(threshold, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithOffset_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var offset = TimeSpan.FromSeconds(5);
+
+        // Act
+        var result = options.WithOffset(offset);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Offset", out var value));
+        Assert.Equal(offset, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithOpenVinoEncoder_SetsAdditionalProperties()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var encoderPath = "path/to/encoder";
+        var device = "CPU";
+        var cachePath = "path/to/cache";
+
+        // Act
+        var result = options.WithOpenVinoEncoder(encoderPath, device, cachePath);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("OpenVinoEncoderPath", out var pathValue));
+        Assert.Equal(encoderPath, pathValue);
+        Assert.True(options.AdditionalProperties.TryGetValue("OpenVinoDevice", out var deviceValue));
+        Assert.Equal(device, deviceValue);
+        Assert.True(options.AdditionalProperties.TryGetValue("OpenVinoCachePath", out var cacheValue));
+        Assert.Equal(cachePath, cacheValue);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithOpenVinoEncoder_WithNullDeviceAndCache_SetsOnlyEncoderPath()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var encoderPath = "path/to/encoder";
+
+        // Act
+        var result = options.WithOpenVinoEncoder(encoderPath);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("OpenVinoEncoderPath", out var pathValue));
+        Assert.Equal(encoderPath, pathValue);
+        Assert.False(options.AdditionalProperties.ContainsKey("OpenVinoDevice"));
+        Assert.False(options.AdditionalProperties.ContainsKey("OpenVinoCachePath"));
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithoutSuppressBlank_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithoutSuppressBlank();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("SuppressBlank", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithoutStringPool_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithoutStringPool();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("StringPool", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintProgress_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintProgress();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintProgress", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintProgress_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintProgress(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintProgress", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintTimestamps_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintTimestamps();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintTimestamps", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintTimestamps_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintTimestamps(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintTimestamps", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintSpecialTokens_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintSpecialTokens();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintSpecialTokens", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintSpecialTokens_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintSpecialTokens(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintSpecialTokens", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintResults_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintResults();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintResults", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithPrintResults_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithPrintResults(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("PrintResults", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithProbabilities_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithProbabilities();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Probabilities", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithProbabilities_WithFalseParameter_SetsAdditionalPropertyToFalse()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithProbabilities(false);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Probabilities", out var value));
+        Assert.False((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithProgressHandler_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        OnProgressHandler handler = (progress) => { };
+
+        // Act
+        var result = options.WithProgressHandler(handler);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("ProgressHandler", out var value));
+        Assert.Same(handler, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithSegmentEventHandler_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        OnSegmentEventHandler handler = (e) => { };
+
+        // Act
+        var result = options.WithSegmentEventHandler(handler);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("SegmentEventHandler", out var value));
+        Assert.Same(handler, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithStringPool_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var stringPool = new TestStringPool();
+
+        // Act
+        var result = options.WithStringPool(stringPool);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("StringPool", out var value));
+        Assert.Same(stringPool, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTemperature_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var temperature = 0.8f;
+
+        // Act
+        var result = options.WithTemperature(temperature);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Temperature", out var value));
+        Assert.Equal(temperature, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTemperatureInc_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var temperatureInc = 0.2f;
+
+        // Act
+        var result = options.WithTemperatureInc(temperatureInc);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("TemperatureInc", out var value));
+        Assert.Equal(temperatureInc, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithThreads_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threads = 4;
+
+        // Act
+        var result = options.WithThreads(threads);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("Threads", out var value));
+        Assert.Equal(threads, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTokenTimestamps_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+
+        // Act
+        var result = options.WithTokenTimestamps();
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("TokenTimestamps", out var value));
+        Assert.True((bool)value!);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTokenTimestampsSumThreshold_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threshold = 0.01f;
+
+        // Act
+        var result = options.WithTokenTimestampsSumThreshold(threshold);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("TokenTimestampsSumThreshold", out var value));
+        Assert.Equal(threshold, value);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void WithTokenTimestampsThreshold_SetsAdditionalProperty()
+    {
+        // Arrange
+        var options = new SpeechToTextOptions();
+        var threshold = 0.01f;
+
+        // Act
+        var result = options.WithTokenTimestampsThreshold(threshold);
+
+        // Assert
+        Assert.NotNull(options.AdditionalProperties);
+        Assert.True(options.AdditionalProperties.TryGetValue("TokenTimestampsThreshold", out var value));
+        Assert.Equal(threshold, value);
+        Assert.Same(options, result);
+    }
+
+    // Helper class for testing
+    private class TestStringPool : IStringPool
+    {
+        public string? GetStringUtf8(IntPtr nativeUtf8) 
+        {
+            return null;
+        }
+
+        public void ReturnString(string? returnedString)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Whisper.net.Tests/SpeechToText/WhisperSpeechToTextClientConstructorTests.cs
+++ b/tests/Whisper.net.Tests/SpeechToText/WhisperSpeechToTextClientConstructorTests.cs
@@ -1,0 +1,193 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using System.Reflection;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Whisper.net.Tests;
+
+public class WhisperSpeechToTextClientConstructorTests : IClassFixture<TinyModelFixture>
+{
+    private readonly TinyModelFixture _model;
+
+    public WhisperSpeechToTextClientConstructorTests(TinyModelFixture model)
+    {
+        _model = model;
+    }
+
+    [Fact]
+    public void Constructor_WithModelFileName_ShouldNotCreateFactoryImmediately()
+    {
+        // Arrange & Act
+        using var client = new WhisperSpeechToTextClient(_model.ModelFile);
+
+        // Assert
+        var factoryField = GetFactoryField(client);
+        Assert.Null(factoryField);
+    }
+
+    [Fact]
+    public void Constructor_WithFactoryBuilder_ShouldNotCreateFactoryImmediately()
+    {
+        // Arrange
+        bool factoryBuilderCalled = false;
+        WhisperFactory FactoryBuilder()
+        {
+            factoryBuilderCalled = true;
+            return WhisperFactory.FromPath(_model.ModelFile);
+        }
+
+        // Act
+        using var client = new WhisperSpeechToTextClient(FactoryBuilder);
+
+        // Assert
+        var factoryField = GetFactoryField(client);
+        Assert.Null(factoryField);
+        Assert.False(factoryBuilderCalled, "Factory builder should not be called until needed");
+    }
+
+    [Fact]
+    public void Constructor_WithNullFactoryBuilder_ShouldThrowArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new WhisperSpeechToTextClient((Func<WhisperFactory>)null!));
+    }
+
+    [Fact]
+    public async Task GetTextAsync_ShouldCreateFactoryLazily()
+    {
+        // Arrange
+        var factoryBuilderCalled = false;
+        WhisperFactory FactoryBuilder()
+        {
+            factoryBuilderCalled = true;
+            return WhisperFactory.FromPath(_model.ModelFile);
+        }
+
+        using var client = new WhisperSpeechToTextClient(FactoryBuilder);
+        
+        // Assert - Before
+        Assert.Null(GetFactoryField(client));
+        Assert.False(factoryBuilderCalled, "Factory builder should not be called until needed");
+
+        // Act
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        var options = new SpeechToTextOptions().WithLanguage("en");
+        await client.GetTextAsync(fileReader, options);
+
+        // Assert - After
+        Assert.NotNull(GetFactoryField(client));
+        Assert.True(factoryBuilderCalled, "Factory builder should be called when GetTextAsync is invoked");
+    }
+
+    [Fact]
+    public async Task GetStreamingTextAsync_ShouldCreateFactoryLazily()
+    {
+        // Arrange
+        var factoryBuilderCalled = false;
+        WhisperFactory FactoryBuilder()
+        {
+            factoryBuilderCalled = true;
+            return WhisperFactory.FromPath(_model.ModelFile);
+        }
+
+        using var client = new WhisperSpeechToTextClient(FactoryBuilder);
+        
+        // Assert - Before
+        Assert.Null(GetFactoryField(client));
+        Assert.False(factoryBuilderCalled, "Factory builder should not be called until needed");
+
+        // Act
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        var options = new SpeechToTextOptions().WithLanguage("en");
+        await foreach (var _ in client.GetStreamingTextAsync(fileReader, options))
+        {
+            // Just consume the stream
+        }
+
+        // Assert - After
+        Assert.NotNull(GetFactoryField(client));
+        Assert.True(factoryBuilderCalled, "Factory builder should be called when GetStreamingTextAsync is invoked");
+    }
+
+    [Fact]
+    public async Task MultipleRequests_ShouldReuseFactory()
+    {
+        // Arrange
+        int factoryBuilderCallCount = 0;
+        WhisperFactory FactoryBuilder()
+        {
+            factoryBuilderCallCount++;
+            return WhisperFactory.FromPath(_model.ModelFile);
+        }
+
+        using var client = new WhisperSpeechToTextClient(FactoryBuilder);
+        var options = new SpeechToTextOptions().WithLanguage("en");
+
+        // Act - First request
+        using (var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav"))
+        {
+            await client.GetTextAsync(fileReader, options);
+        }
+
+        var factoryAfterFirstRequest = GetFactoryField(client);
+        Assert.NotNull(factoryAfterFirstRequest);
+        Assert.Equal(1, factoryBuilderCallCount);
+
+        // Act - Second request
+        using (var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav"))
+        {
+            await client.GetTextAsync(fileReader, options);
+        }
+
+        // Assert
+        var factoryAfterSecondRequest = GetFactoryField(client);
+        Assert.NotNull(factoryAfterSecondRequest);
+        Assert.Equal(1, factoryBuilderCallCount); // Factory builder should only be called once
+        Assert.Same(factoryAfterFirstRequest, factoryAfterSecondRequest); // he same factory instance should be reused
+    }
+
+    [Fact]
+    public async Task Dispose_ShouldDisposeFactory()
+    {
+        // Arrange
+        using var client = new WhisperSpeechToTextClient(_model.ModelFile);
+        var options = new SpeechToTextOptions().WithLanguage("en");
+
+        // Act - Create factory by using the client
+        using (var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav"))
+        {
+            await client.GetTextAsync(fileReader, options);
+        }
+
+        var factory = GetFactoryField(client);
+        Assert.NotNull(factory);
+
+        // Act - Dispose the client
+        client.Dispose();
+
+        // Assert
+        // After disposal, the factory field should be null
+        Assert.Null(GetFactoryField(client));
+    }
+
+    [Fact]
+    public async Task FactoryBuilder_ReturningNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        using var client = new WhisperSpeechToTextClient(() => null!);
+        var options = new SpeechToTextOptions().WithLanguage("en");
+
+        // Act & Assert
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTextAsync(fileReader, options));
+    }
+
+    private static WhisperFactory? GetFactoryField(WhisperSpeechToTextClient client)
+    {
+        var fieldInfo = typeof(WhisperSpeechToTextClient).GetField("_factory", BindingFlags.NonPublic | BindingFlags.Instance);
+        return fieldInfo?.GetValue(client) as WhisperFactory;
+    }
+}

--- a/tests/Whisper.net.Tests/SpeechToText/WhisperSpeechToTextClientTest.cs
+++ b/tests/Whisper.net.Tests/SpeechToText/WhisperSpeechToTextClientTest.cs
@@ -1,0 +1,206 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Microsoft.Extensions.AI;
+using Xunit;
+using static Whisper.net.Tests.ProcessAsyncFunctionalTests;
+
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Whisper.net.Tests;
+public partial class WhisperSpeechToTextClientTest(TinyModelFixture model) : IClassFixture<TinyModelFixture>
+{
+    /*
+    [Fact]
+    public async Task TestHappyFlowAsync()
+    {
+        var segments = new List<SegmentData>();
+        var segmentsEnumerated = new List<SegmentData>();
+        var progress = new List<int>();
+
+        var encoderBegins = new List<EncoderBeginData>();
+        using var factory = WhisperFactory.FromPath(model.ModelFile);
+        using var processor = factory.CreateBuilder()
+                        .WithLanguage("en")
+                        .WithEncoderBeginHandler((e) =>
+                        {
+                            encoderBegins.Add(e);
+                            return true;
+                        })
+                        .WithProgressHandler(progress.Add)
+                        .WithSegmentEventHandler(segments.Add)
+                        .Build();
+
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        await foreach (var data in processor.ProcessAsync(fileReader))
+        {
+            segmentsEnumerated.Add(data);
+        }
+
+        Assert.Equal(segments, segmentsEnumerated);
+        Assert.True(segments.Count > 0);
+        Assert.True(progress.SequenceEqual(progress.OrderBy(x => x)));
+        Assert.True(progress.Count > 1);
+        Assert.Single(encoderBegins);
+        Assert.Contains(segments, segmentData => segmentData.Text.Contains("nation should commit"));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Cancelled_WillCancellTheProcessing_AndDispose_WillWaitUntilFullyFinished()
+    {
+        var segments = new List<SegmentData>();
+        var segmentsEnumerated = new List<SegmentData>();
+        var cts = new CancellationTokenSource();
+        TaskCanceledException? taskCanceledException = null;
+
+        var encoderBegins = new List<EncoderBeginData>();
+        using var factory = WhisperFactory.FromPath(model.ModelFile);
+        var processor = factory.CreateBuilder()
+                        .WithLanguage("en")
+                        .WithEncoderBeginHandler((e) =>
+                        {
+                            encoderBegins.Add(e);
+                            return true;
+                        })
+                        .WithSegmentEventHandler(s =>
+                        {
+                            segments.Add(s);
+                            cts.Cancel();
+                        })
+                        .Build();
+
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        try
+        {
+            await foreach (var data in processor.ProcessAsync(fileReader, cts.Token))
+            {
+                segmentsEnumerated.Add(data);
+            }
+        }
+        catch (TaskCanceledException ex)
+        {
+            taskCanceledException = ex;
+        }
+
+        await processor.DisposeAsync();
+
+        Assert.Empty(segmentsEnumerated);
+        Assert.Single( segments);
+        Assert.Single( encoderBegins);
+        Assert.NotNull(taskCanceledException);
+        Assert.Contains(segments, segmentData => segmentData.Text.Contains("nation should commit"));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenJunkChunkExists_ProcessCorrectly()
+    {
+        var segments = new List<SegmentData>();
+
+        using var factory = WhisperFactory.FromPath(model.ModelFile);
+        await using var processor = factory.CreateBuilder()
+                        .WithLanguage("en")
+                        .Build();
+
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("junkchunk16khz.wav");
+        await foreach (var segment in processor.ProcessAsync(fileReader))
+        {
+            segments.Add(segment);
+        }
+
+        Assert.True(segments.Count >= 1);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenMultichannel_ProcessCorrectly()
+    {
+        var segments = new List<SegmentData>();
+
+        using var factory = WhisperFactory.FromPath(model.ModelFile);
+        await using var processor = factory.CreateBuilder()
+                        .WithLanguage("en")
+                        .Build();
+
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("multichannel.wav");
+        await foreach (var segment in processor.ProcessAsync(fileReader))
+        {
+            segments.Add(segment);
+        }
+
+        Assert.True(segments.Count >= 1);
+    }*/
+
+    [Fact]
+    public async Task GetStreamingTextAsync_CalledMultipleTimes_Serially_WillCompleteEverytime()
+    {
+        var updates1 = new List<SpeechToTextResponseUpdate>();
+        var updates2 = new List<SpeechToTextResponseUpdate>();
+        var updates3 = new List<SpeechToTextResponseUpdate>();
+
+        var client = new WhisperSpeechToTextClient(model.ModelFile);
+        var options = new SpeechToTextOptions().WithLanguage("en");
+
+        using var fileReader = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        await foreach (var update in client.GetStreamingTextAsync(fileReader, options))
+        {
+            updates1.Add(update);
+        }
+
+        using var fileReader2 = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        await foreach (var update in client.GetStreamingTextAsync(fileReader2, options))
+        {
+            updates2.Add(update);
+        }
+
+        using var fileReader3 = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        await foreach (var update in client.GetStreamingTextAsync(fileReader3, options))
+        {
+            updates3.Add(update);
+        }
+
+        Assert.True(updates1.SequenceEqual(updates2, new UpdateDataComparer()));
+        Assert.True(updates2.SequenceEqual(updates3, new UpdateDataComparer()));
+    }
+
+    [Fact]
+    public async Task GetTextAsync_CalledMultipleTimes_Serially_WillCompleteEverytime()
+    {
+        var client = new WhisperSpeechToTextClient(model.ModelFile);
+        var options = new SpeechToTextOptions().WithLanguage("en");
+
+        using var fileReader1 = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        var result1 = await client.GetTextAsync(fileReader1, options);
+        var segments1 = Assert.IsAssignableFrom<IEnumerable<SegmentData>>(result1.RawRepresentation);
+
+        using var fileReader2 = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        var result2 = await client.GetTextAsync(fileReader2, options);
+        var segments2 = Assert.IsAssignableFrom<IEnumerable<SegmentData>>(result2.RawRepresentation);
+
+        using var fileReader3 = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        var result3 = await client.GetTextAsync(fileReader3, options);
+        var segments3 = Assert.IsAssignableFrom<IEnumerable<SegmentData>>(result3.RawRepresentation);
+        
+
+        Assert.True(segments1.SequenceEqual(segments2, new SegmentDataComparer()));
+        Assert.True(segments2.SequenceEqual(segments3, new SegmentDataComparer()));
+    }
+
+    private  class UpdateDataComparer : IEqualityComparer<SpeechToTextResponseUpdate>
+    {
+        public bool Equals(SpeechToTextResponseUpdate? xUpdate, SpeechToTextResponseUpdate? yUpdate)
+        {
+            if (xUpdate == null || yUpdate == null)
+            {
+                return false;
+            }
+
+            var x = (yUpdate.RawRepresentation as SegmentData)!;
+            var y = (yUpdate.RawRepresentation as SegmentData)!;
+
+            return x.Text == y.Text && x.MinProbability == y.MinProbability && x.Probability == y.Probability && x.Start == y.Start && x.End == y.End; // Compare by relevant properties
+        }
+
+        public int GetHashCode(SpeechToTextResponseUpdate obj)
+        {
+            return obj.Text.GetHashCode();
+        }
+    }
+}

--- a/tools/WhisperNetDependencyChecker/DependencyWalker/INativeLibraryLoader.cs
+++ b/tools/WhisperNetDependencyChecker/DependencyWalker/INativeLibraryLoader.cs
@@ -1,3 +1,5 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
 namespace WhisperNetDependencyChecker.DependencyWalker;
 
 internal interface INativeLibraryLoader

--- a/tools/WhisperNetDependencyChecker/DependencyWalker/NativeLibraryChecker.cs
+++ b/tools/WhisperNetDependencyChecker/DependencyWalker/NativeLibraryChecker.cs
@@ -1,3 +1,5 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
 namespace WhisperNetDependencyChecker.DependencyWalker;
 
 using System;


### PR DESCRIPTION
This implementation adds support to the latest `ISpeechToTextClient` abstraction from the `Microsoft.Extensions.AI.Abstractions` package.

- Updated Runtime version
- Added implementation for the client using same pattern `With` for adding options.
- Added Demo for the new client
- Minor warning fixes (blank lines, missing headers, unused usings)