### PR TITLE
Fix memory management for OpenVINO init

### DIFF
--- a/Whisper.net/WhisperFactory.cs
+++ b/Whisper.net/WhisperFactory.cs
@@ -67,7 +67,8 @@ public sealed class WhisperFactory : IDisposable
 
         var systemInfoPtr = libraryLoaded.Value.NativeWhisper!.WhisperPrintSystemInfo();
         var systemInfoStr = Marshal.PtrToStringAnsi(systemInfoPtr);
-        Marshal.FreeHGlobal(systemInfoPtr);
+        // The pointer returned by WhisperPrintSystemInfo points to a static
+        // buffer owned by the native library. Do not free it here.
         return systemInfoStr;
     }
 

--- a/Whisper.net/WhisperProcessor.cs
+++ b/Whisper.net/WhisperProcessor.cs
@@ -362,12 +362,22 @@ public sealed class WhisperProcessor : IAsyncDisposable, IDisposable
             var modelPath = Marshal.StringToHGlobalAnsi(options.OpenVinoModelPath);
             var device = Marshal.StringToHGlobalAnsi(options.OpenVinoDevice);
             var cachePath = Marshal.StringToHGlobalAnsi(options.OpenVinoCacheDir);
-            nativeWhisper.Whisper_Ctx_Init_Openvino_Encoder_With_State(
-                options.ContextHandle,
-                state,
-                modelPath,
-                device,
-                cachePath);
+
+            try
+            {
+                nativeWhisper.Whisper_Ctx_Init_Openvino_Encoder_With_State(
+                    options.ContextHandle,
+                    state,
+                    modelPath,
+                    device,
+                    cachePath);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(modelPath);
+                Marshal.FreeHGlobal(device);
+                Marshal.FreeHGlobal(cachePath);
+            }
         }
         return state;
     }


### PR DESCRIPTION
## Summary
- correctly free temporary strings when initializing the OpenVINO encoder
- install .NET 8 and .NET 9 SDKs to run tests

## Testing
- `dotnet test Whisper.net.sln` *(fails: missing native runtime files)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2df41148323b1b8a1303da5fc74