### PR TITLE
Add artifact upload release workflow

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -131,3 +131,20 @@ jobs:
          - linux
       uses: ./.github/workflows/dotnet-maui.yml
       secrets: inherit
+
+   upload-build-artifacts:
+      needs:
+         - android
+         - macos
+         - windows
+         - wasm
+         - linux
+         - windows-vulkan
+         - linux-vulkan
+         - windows-openvino
+         - linux-openvino
+         - windows-no-avx
+         - linux-no-avx
+      uses: ./.github/workflows/upload-build-artifacts.yml
+      secrets: inherit
+

--- a/.github/workflows/upload-build-artifacts.yml
+++ b/.github/workflows/upload-build-artifacts.yml
@@ -1,0 +1,34 @@
+name: Upload Build Artifacts
+
+permissions:
+  contents: write
+
+on:
+  workflow_call:
+
+jobs:
+  upload-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: runtime-artifacts
+
+      - name: Set release info
+        id: release-info
+        run: |
+          echo "date=$(date -u +'%Y%m%d-%H%M')" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git -C whisper.cpp rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create preview release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: preview-${{ steps.release-info.outputs.date }}-${{ steps.release-info.outputs.commit }}
+          name: Preview ${{ steps.release-info.outputs.date }} (${{ steps.release-info.outputs.commit }})
+          artifacts: runtime-artifacts/**
+          prerelease: true


### PR DESCRIPTION
## Summary
- create reusable workflow to upload build artifacts to a preview GitHub release
- invoke workflow from build-all CI after all native builds

## Testing
- `dotnet test Whisper.net.sln` *(fails: Could not copy the file ...)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5089e6c8323a1e46d39bbe34959