### PR TITLE
Split iOS build job

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -39,6 +39,16 @@ jobs:
       with:
          BuildConfig: ${{ inputs.BuildConfig || 'Release'}}
 
+   ios:
+      uses: ./.github/workflows/ios-native-build.yml
+      with:
+         BuildConfig: ${{ inputs.BuildConfig || 'Release'}}
+
+   tvos:
+      uses: ./.github/workflows/tvos-native-build.yml
+      with:
+         BuildConfig: ${{ inputs.BuildConfig || 'Release'}}
+
    windows:
       uses: ./.github/workflows/windows-native-build.yml
       with:
@@ -112,6 +122,8 @@ jobs:
       needs:
          - android
          - macos
+         - ios
+         - tvos
          - windows
          - wasm
          - linux
@@ -126,6 +138,8 @@ jobs:
       needs:
          - android
          - macos
+         - ios
+         - tvos
          - windows
          - wasm
          - linux
@@ -136,6 +150,8 @@ jobs:
       needs:
          - android
          - macos
+         - ios
+         - tvos
          - windows
          - wasm
          - linux

--- a/.github/workflows/ios-native-build.yml
+++ b/.github/workflows/ios-native-build.yml
@@ -1,0 +1,35 @@
+name: Apple iOS native build
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      BuildConfig:
+        required: true
+        type: string
+        default: 'Release'
+
+jobs:
+  ios-native-build:
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run iOS build
+        run: |
+          make ios ios_simulator_arm64 BUILD_TYPE=${{ inputs.BuildConfig }}
+
+      - name: Upload iOS Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-build
+          path: |
+            runtimes/Whisper.net.Run*/*/*
+            runtimes/Whisper.net.Run*/*.metal
+          retention-days: 7

--- a/.github/workflows/macos-native-build.yml
+++ b/.github/workflows/macos-native-build.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Run apple build for arm
+      - name: Run macos build for arm and Mac Catalyst
         run: |
-          make apple_arm BUILD_TYPE=${{ inputs.BuildConfig }}
+          make macos_arm64 maccatalyst_arm64 BUILD_TYPE=${{ inputs.BuildConfig }}
 
       - name: Upload Mac Arm Build Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,12 @@ jobs:
    macos:
       uses: ./.github/workflows/macos-native-build.yml
 
+   ios:
+      uses: ./.github/workflows/ios-native-build.yml
+
+   tvos:
+      uses: ./.github/workflows/tvos-native-build.yml
+
    windows:
       uses: ./.github/workflows/windows-native-build.yml
       
@@ -74,6 +80,8 @@ jobs:
       needs:
          - android
          - macos
+         - ios
+         - tvos
          - windows
          - wasm
          - linux

--- a/.github/workflows/tvos-native-build.yml
+++ b/.github/workflows/tvos-native-build.yml
@@ -1,0 +1,35 @@
+name: Apple tvOS native build
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      BuildConfig:
+        required: true
+        type: string
+        default: 'Release'
+
+jobs:
+  tvos-native-build:
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run tvOS build
+        run: |
+          make tvos tvos_simulator_arm64 BUILD_TYPE=${{ inputs.BuildConfig }}
+
+      - name: Upload tvOS Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tvos-build
+          path: |
+            runtimes/Whisper.net.Run*/*/*
+            runtimes/Whisper.net.Run*/*.metal
+          retention-days: 7


### PR DESCRIPTION
## Summary
- stop building tvOS and Mac Catalyst in the iOS workflow
- create a dedicated workflow for building tvOS binaries
- move Mac Catalyst arm build back to the macOS workflow
- update build and release pipelines to use the new jobs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a9b1f4083239f5279eafdf4c6ad