### PR TITLE
Fix artifact workflow submodule checkout

### DIFF
--- a/.github/workflows/upload-build-artifacts.yml
+++ b/.github/workflows/upload-build-artifacts.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set release info
         id: release-info


### PR DESCRIPTION
## Summary
- ensure `whisper.cpp` submodule is checked out in the artifact upload workflow

## Testing
- `dotnet test Whisper.net.sln` *(fails: required native runtime files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513a50ebdc83238dc2200aa5c9c3e7