### PR TITLE
Add permissive wave parser option

### DIFF
--- a/Whisper.net/Wave/WaveParser.cs
+++ b/Whisper.net/Wave/WaveParser.cs
@@ -11,7 +11,8 @@ namespace Whisper.net.Wave;
 /// The 
 /// </remarks>
 /// <param name="waveStream">The wave stream to be processed.</param>
-public sealed class WaveParser(Stream waveStream)
+/// <param name="options">Parser options. Optional.</param>
+public sealed class WaveParser(Stream waveStream, WaveParserOptions? options = null)
 {
     private static readonly byte[] expectedSubFormatForPcm = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71];
     private ushort channels;
@@ -20,6 +21,7 @@ public sealed class WaveParser(Stream waveStream)
     private uint dataChunkSize;
     private long dataChunkPosition;
     private bool isInitialized;
+    private readonly WaveParserOptions options = options ?? new();
 
     /// <summary>
     /// Gets the number of channels in the current wave file.
@@ -254,7 +256,7 @@ public sealed class WaveParser(Stream waveStream)
             }
         }
 
-        if (sampleIndex < SamplesCount)
+        if (sampleIndex < SamplesCount && !options.AllowLessSamples)
         {
             throw new CorruptedWaveException("Invalid wave file, the size is too small and couldn't read all the samples.");
         }

--- a/Whisper.net/Wave/WaveParserOptions.cs
+++ b/Whisper.net/Wave/WaveParserOptions.cs
@@ -1,0 +1,14 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+namespace Whisper.net.Wave;
+
+/// <summary>
+/// Options for configuring the <see cref="WaveParser"/>.
+/// </summary>
+public sealed class WaveParserOptions
+{
+    /// <summary>
+    /// Allows reading truncated wave files without throwing <see cref="CorruptedWaveException"/>.
+    /// </summary>
+    public bool AllowLessSamples { get; set; }
+}

--- a/tests/Whisper.net.Tests/WaveParserTests.cs
+++ b/tests/Whisper.net.Tests/WaveParserTests.cs
@@ -1,0 +1,44 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Whisper.net.Wave;
+using Xunit;
+
+namespace Whisper.net.Tests;
+
+public class WaveParserTests
+{
+    [Fact]
+    public async Task Initialize_WithTruncatedStream_ShouldThrow()
+    {
+        await using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+
+        var truncatedBytes = new byte[stream.Length - 1000];
+        var read = await stream.ReadAsync(truncatedBytes);
+        Assert.Equal(truncatedBytes.Length, read);
+
+        using var truncated = new MemoryStream(truncatedBytes);
+
+        var parser = new WaveParser(truncated);
+
+        await Assert.ThrowsAsync<CorruptedWaveException>(() => parser.GetAvgSamplesAsync());
+    }
+
+    [Fact]
+    public async Task Initialize_WithTruncatedStreamAndPermissiveFlag_ShouldNotThrow()
+    {
+        await using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+
+        var truncatedBytes = new byte[stream.Length - 1000];
+        var read = await stream.ReadAsync(truncatedBytes);
+        Assert.Equal(truncatedBytes.Length, read);
+
+        using var truncated = new MemoryStream(truncatedBytes);
+
+        var parser = new WaveParser(truncated, new WaveParserOptions { AllowLessSamples = true });
+
+        var samples = await parser.GetAvgSamplesAsync();
+
+        Assert.NotNull(samples);
+    }
+}
+

--- a/tests/Whisper.net.Tests/WaveParserTests.cs
+++ b/tests/Whisper.net.Tests/WaveParserTests.cs
@@ -10,10 +10,10 @@ public class WaveParserTests
     [Fact]
     public async Task Initialize_WithTruncatedStream_ShouldThrow()
     {
-        await using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
 
         var truncatedBytes = new byte[stream.Length - 1000];
-        var read = await stream.ReadAsync(truncatedBytes);
+        var read = await stream.ReadAsync(truncatedBytes, 0, truncatedBytes.Length);
         Assert.Equal(truncatedBytes.Length, read);
 
         using var truncated = new MemoryStream(truncatedBytes);
@@ -26,10 +26,10 @@ public class WaveParserTests
     [Fact]
     public async Task Initialize_WithTruncatedStreamAndPermissiveFlag_ShouldNotThrow()
     {
-        await using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
+        using var stream = await TestDataProvider.OpenFileStreamAsync("kennedy.wav");
 
         var truncatedBytes = new byte[stream.Length - 1000];
-        var read = await stream.ReadAsync(truncatedBytes);
+        var read = await stream.ReadAsync(truncatedBytes, 0, truncatedBytes.Length);
         Assert.Equal(truncatedBytes.Length, read);
 
         using var truncated = new MemoryStream(truncatedBytes);


### PR DESCRIPTION
## Summary
- allow WaveParser to ignore truncated wave data when specified
- test default strict behavior vs new permissive mode
- expose new WaveParserOptions to configure future parser settings

## Testing
- `dotnet test tests/Whisper.net.Tests/Whisper.net.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68513ba194b08323b52bf7bc709e0ae7