### PR TITLE
Update Windows runner version

### DIFF
--- a/.github/workflows/windows-cuda-native-build.yml
+++ b/.github/workflows/windows-cuda-native-build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   native-build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows-native-build.yml
+++ b/.github/workflows/windows-native-build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   intel-native-build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,8 @@ The default runtime that uses the CPU for inference. It is available on all plat
 
 #### Pre-requisites
 
- - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2019 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
+ - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2022 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
+ - Windows 11 or Windows Server 2022 (or newer) is required
  - Linux: `libstdc++6`, `glibc 2.31`
  - macOS: TBD
  - For x86/x64 platforms, the CPU must support AVX, AVX2, FMA and F16C instructions. If your CPU does not support these instructions, you'll need to use the `Whisper.net.Runtime.NoAvx` runtime instead.
@@ -84,7 +85,8 @@ For CPUs that do not support AVX instructions.
 
 #### Pre-requisites
 
- - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2019 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
+ - Windows: Microsoft Visual C++ Redistributable for at least Visual Studio 2022 (x64) [Download Link](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version)
+ - Windows 11 or Windows Server 2022 (or newer) is required
  - Linux: `libstdc++6`, `glibc 2.31`
  - macOS: TBD
 


### PR DESCRIPTION
## Summary
- update Windows native build runner to Windows 2022
- update Windows CUDA build runner to Windows 2022
- clarify Windows 11/Windows Server 2022 as the minimum supported version

## Testing
- `dotnet test ./tests/Whisper.net.Tests/Whisper.net.Tests.csproj -f net8.0 --logger "trx"` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851af5b49c08323a9aa9886de14c7a9