### PR TITLE
Add runner info workflow

### DIFF
--- a/.github/workflows/runner-info.yml
+++ b/.github/workflows/runner-info.yml
@@ -1,0 +1,23 @@
+name: Runner Info
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  show-runner:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Print runner information
+        run: |
+          echo "Runner OS: $RUNNER_OS"
+          echo "Runner Name: $RUNNER_NAME"
+          echo "Architecture: $(uname -m 2>/dev/null || echo 'N/A')"
+          echo "Machine info:";
+          uname -a || ver || systeminfo || true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to print runner details for debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68687a64d6348323863a26481eebca84