### PR TITLE
Fixed concurrent collection access crash

### DIFF
--- a/Whisper.net/WhisperProcessor.cs
+++ b/Whisper.net/WhisperProcessor.cs
@@ -229,7 +229,10 @@ public sealed class WhisperProcessor : IAsyncDisposable, IDisposable
 
         try
         {
-            options.OnSegmentEventHandlers.Add(OnSegmentHandler);
+            lock (options.OnSegmentEventHandlers)
+            {
+                options.OnSegmentEventHandlers.Add(OnSegmentHandler);
+            }
             options.WhisperAbortEventHandler = OnWhisperAbortHandler;
 
             currentCancellationToken = cancellationToken;
@@ -261,7 +264,10 @@ public sealed class WhisperProcessor : IAsyncDisposable, IDisposable
         }
         finally
         {
-            options.OnSegmentEventHandlers.Remove(OnSegmentHandler);
+            lock (options.OnSegmentEventHandlers)
+            {
+                options.OnSegmentEventHandlers.Remove(OnSegmentHandler);
+            }
         }
     }
 
@@ -776,7 +782,9 @@ public sealed class WhisperProcessor : IAsyncDisposable, IDisposable
                     language!,
                     tokens);
 
-                foreach (var handler in options.OnSegmentEventHandlers)
+                OnSegmentEventHandler[] handlers;
+                lock (options.OnSegmentEventHandlers) { handlers = options.OnSegmentEventHandlers.ToArray(); }
+                foreach (var handler in handlers)
                 {
                     handler?.Invoke(eventHandlerArgs);
                     if (currentCancellationToken.HasValue && currentCancellationToken.Value.IsCancellationRequested)


### PR DESCRIPTION
The way the segment event handlers were being dispatched caused a rare exception if a new handler was added/removed by ProcessAsync:

Unhandled exception. System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
at Whisper.net.WhisperProcessor.OnNewSegment(IntPtr state)
at Whisper.net.WhisperProcessor.OnNewSegmentStatic(IntPtr ctx, IntPtr state, Int32 nNew, IntPtr userData)

This patch fixes the crash by preventing concurrent access to the collection.