### PR TITLE
Extract ggml-metal shader into dedicated runtime package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,18 @@ NOAVX_SUPPORT=-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
 NDK := $(if $(strip $(NDK_PATH)),$(NDK_PATH),$(shell test -d $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle && echo $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle || echo ""))
 
 nuget:
-	mkdir -p nupkgs
-	nuget pack runtimes/Whisper.net.Runtime.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
-	dotnet pack Whisper.net/Whisper.net.csproj -p:Version=$(VERSION) -o ./nupkgs -c $(BUILD_TYPE)
-	nuget pack runtimes/Whisper.net.Runtime.CoreML.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+        mkdir -p nupkgs
+        nuget pack runtimes/Whisper.net.Runtime.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+        nuget pack runtimes/Whisper.net.Runtime.Metal.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+        dotnet pack Whisper.net/Whisper.net.csproj -p:Version=$(VERSION) -o ./nupkgs -c $(BUILD_TYPE)
+        nuget pack runtimes/Whisper.net.Runtime.CoreML.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.Linux.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.Windows.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Vulkan.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.OpenVino.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.NoAvx.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
-	nuget pack runtimes/Whisper.net.Runtime.AllRuntimes.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+        nuget pack runtimes/Whisper.net.AllRuntimes.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 
 clean:
 	rm -rf nupkgs
@@ -26,10 +27,10 @@ clean:
 android: android_x64 android_x86 android_arm64-v8a
 
 apple_x64: copy_metal macos_x64
-apple_arm: macos_arm64 ios maccatalyst_arm64  ios_simulator_arm64  tvos_simulator_arm64 tvos
+apple_arm: copy_metal macos_arm64 ios maccatalyst_arm64  ios_simulator_arm64  tvos_simulator_arm64 tvos
 
-apple_coreml_x64: copy_metal_coreml macos_x64_coreml
-apple_coreml_arm: macos_arm64_coreml ios_coreml  maccatalyst_arm64_coreml ios_simulator_coreml
+apple_coreml_x64: copy_metal macos_x64_coreml
+apple_coreml_arm: copy_metal macos_arm64_coreml ios_coreml  maccatalyst_arm64_coreml ios_simulator_coreml
 
 linux: linux_x64 linux_arm64 linux_arm
 
@@ -40,10 +41,7 @@ linux_cuda: linux_x64_cuda
 linux_vulkan: linux_x64_vulkan
 
 copy_metal:
-	cp whisper.cpp/ggml/src/ggml-metal/ggml-metal.metal runtimes/Whisper.net.Runtime/ggml-metal.metal
-
-copy_metal_coreml:
-	cp whisper.cpp/ggml/src/ggml-metal/ggml-metal.metal runtimes/Whisper.net.Runtime.CoreML/ggml-metal.metal
+        cp whisper.cpp/ggml/src/ggml-metal/ggml-metal.metal runtimes/Whisper.net.Runtime.Metal/ggml-metal.metal
 
  # WASM hack to run under bash as emcmake overrides env variables and cannot run cmake anymore.
 wasm:

--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,18 @@ NOAVX_SUPPORT=-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
 NDK := $(if $(strip $(NDK_PATH)),$(NDK_PATH),$(shell test -d $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle && echo $(HOME)/Library/Developer/Xamarin/android-sdk-macosx/ndk-bundle || echo ""))
 
 nuget:
-        mkdir -p nupkgs
-        nuget pack runtimes/Whisper.net.Runtime.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
-        nuget pack runtimes/Whisper.net.Runtime.Metal.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
-        dotnet pack Whisper.net/Whisper.net.csproj -p:Version=$(VERSION) -o ./nupkgs -c $(BUILD_TYPE)
-        nuget pack runtimes/Whisper.net.Runtime.CoreML.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+	mkdir -p nupkgs
+	nuget pack runtimes/Whisper.net.Runtime.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+	nuget pack runtimes/Whisper.net.Runtime.Metal.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+	dotnet pack Whisper.net/Whisper.net.csproj -p:Version=$(VERSION) -o ./nupkgs -c $(BUILD_TYPE)
+	nuget pack runtimes/Whisper.net.Runtime.CoreML.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.Linux.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.Windows.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Cuda.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.Vulkan.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.OpenVino.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 	nuget pack runtimes/Whisper.net.Runtime.NoAvx.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
-        nuget pack runtimes/Whisper.net.AllRuntimes.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
+	nuget pack runtimes/Whisper.net.AllRuntimes.nuspec -Version $(VERSION) -OutputDirectory ./nupkgs
 
 clean:
 	rm -rf nupkgs
@@ -41,7 +41,7 @@ linux_cuda: linux_x64_cuda
 linux_vulkan: linux_x64_vulkan
 
 copy_metal:
-        cp whisper.cpp/ggml/src/ggml-metal/ggml-metal.metal runtimes/Whisper.net.Runtime.Metal/ggml-metal.metal
+	cp whisper.cpp/ggml/src/ggml-metal/ggml-metal.metal runtimes/Whisper.net.Runtime.Metal/ggml-metal.metal
 
  # WASM hack to run under bash as emcmake overrides env variables and cannot run cmake anymore.
 wasm:

--- a/Whisper.net.Demo/Whisper.net.Demo.csproj
+++ b/Whisper.net.Demo/Whisper.net.Demo.csproj
@@ -5,6 +5,8 @@
           Project="../runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets" />
   <Import Condition="'$(EnableCoreML)' != 'true' AND $(USE_WHISPER_NOAVX_TESTS) != ''"
           Project="../runtimes/Whisper.net.Runtime.NoAvx/Whisper.net.Runtime.NoAvx.targets" />
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets" />
 
   <PropertyGroup>
 		<OutputType>Exe</OutputType>

--- a/runtimes/Whisper.net.AllRuntimes.nuspec
+++ b/runtimes/Whisper.net.AllRuntimes.nuspec
@@ -18,6 +18,7 @@
       <dependency id="Whisper.net.Runtime" version="$version$" />
       <dependency id="Whisper.net.Runtime.Cuda" version="$version$" />
       <dependency id="Whisper.net.Runtime.CoreML" version="$version$" />
+      <dependency id="Whisper.net.Runtime.Metal" version="$version$" />
       <dependency id="Whisper.net.Runtime.NoAvx" version="$version$" />
       <dependency id="Whisper.net.Runtime.OpenVino" version="$version$" />
       <dependency id="Whisper.net.Runtime.Vulkan" version="$version$" />

--- a/runtimes/Whisper.net.Runtime.CoreML.nuspec
+++ b/runtimes/Whisper.net.Runtime.CoreML.nuspec
@@ -13,6 +13,9 @@
     <projectUrl>https://github.com/sandrohanea/whisper.net</projectUrl>
     <license type="expression">MIT</license>
     <readme>content/readme.md</readme>
+    <dependencies>
+      <dependency id="Whisper.net.Runtime.Metal" version="$version$" />
+    </dependencies>
   </metadata>
   <files>
     <file src="Whisper.net.Runtime.CoreML\**" target="build"/>

--- a/runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets
+++ b/runtimes/Whisper.net.Runtime.CoreML/Whisper.net.Runtime.CoreML.targets
@@ -118,22 +118,6 @@
       <TargetPath>runtimes/maccatalyst/libggml-blas-whisper.dylib</TargetPath>
     </None>
   </ItemGroup>
-  <!-- Metal Maui asset for maccatalyst, ios, tvos and their simulators -->
-  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or (('$(Platform)' == 'iPhone') OR ('$(RuntimeIdentifier)' == 'ios') OR $(RuntimeIdentifier.StartsWith('ios-')) OR $(RuntimeIdentifier.StartsWith('ios.'))) or $(TargetFramework.Contains('-maccatalyst')) == true or (('$(Platform)' == 'iPhoneSimulator') OR $(RuntimeIdentifier.StartsWith('iossimulator')))">
-    <MauiAsset Include="$(MSBuildThisFileDirectory)\ggml-metal.metal" LogicalName="ggml-metal.metal" />
-  </ItemGroup>
-
-  <!-- Metal Copy For MacOS -->
-  <ItemGroup Condition="$(TargetFramework.Contains('-')) == false">
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)\ggml-metal.metal">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>ggml-metal.metal</TargetPath>
-      <PublishFolderType>RootDirectory</PublishFolderType>
-    </None>
-  </ItemGroup>
-
   <ItemGroup Condition="$(TargetFramework.Contains('-')) == false ">
     <None Visible="false" Include="$(MSBuildThisFileDirectory)macos-x64\libwhisper.dylib">
       <Pack>true</Pack>

--- a/runtimes/Whisper.net.Runtime.Metal.nuspec
+++ b/runtimes/Whisper.net.Runtime.Metal.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Whisper.net.Runtime.Metal</id>
+    <title>Whisper.Net.Runtime.Metal</title>
+    <version>$version$</version>
+    <authors>Sandro Hanea</authors>
+    <owners>Sandro Hanea</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Metal shader for Whisper runtimes.</summary>
+    <description>Whisper.net.Runtime.Metal contains the ggml metal shader used by Whisper.net runtimes.</description>
+    <tags>whisper;ios;macos;maccatalyst;tvos;metal</tags>
+    <projectUrl>https://github.com/sandrohanea/whisper.net</projectUrl>
+    <license type="expression">MIT</license>
+    <readme>content/readme.md</readme>
+  </metadata>
+  <files>
+    <file src="Whisper.net.Runtime.Metal\**" target="build"/>
+    <file src="../readme.md" target="content/readme.md" />
+  </files>
+</package>

--- a/runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets
+++ b/runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets
@@ -1,0 +1,18 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Metal Maui asset for maccatalyst, ios, tvos and their simulators -->
+  <ItemGroup
+    Condition="$(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or (('$(Platform)' == 'iPhone') OR ('$(RuntimeIdentifier)' == 'ios') OR $(RuntimeIdentifier.StartsWith('ios-')) OR $(RuntimeIdentifier.StartsWith('ios.'))) or $(TargetFramework.Contains('-maccatalyst')) == true or (('$(Platform)' == 'iPhoneSimulator') OR $(RuntimeIdentifier.StartsWith('iossimulator')))">
+    <MauiAsset Include="$(MSBuildThisFileDirectory)ggml-metal.metal" LogicalName="ggml-metal.metal" />
+  </ItemGroup>
+
+  <!-- Metal Copy For MacOS -->
+  <ItemGroup Condition="$(TargetFramework.Contains('-macos')) == true or $(TargetFramework.Contains('-')) == false">
+    <None Visible="false" Include="$(MSBuildThisFileDirectory)ggml-metal.metal">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>ggml-metal.metal</TargetPath>
+      <PublishFolderType>RootDirectory</PublishFolderType>
+    </None>
+  </ItemGroup>
+</Project>

--- a/runtimes/Whisper.net.Runtime.nuspec
+++ b/runtimes/Whisper.net.Runtime.nuspec
@@ -13,6 +13,9 @@
     <projectUrl>https://github.com/sandrohanea/whisper.net</projectUrl>
     <license type="expression">MIT</license>
     <readme>content/readme.md</readme>
+    <dependencies>
+      <dependency id="Whisper.net.Runtime.Metal" version="$version$" />
+    </dependencies>
   </metadata>
   <files>
     <file src="Whisper.net.Runtime\**" target="build"/>

--- a/runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets
+++ b/runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets
@@ -537,20 +537,4 @@
   </ItemGroup>
   <!-- End Wasm -->
 
-  <!-- Metal Maui asset for maccatalyst, ios, tvos and their simulators -->
-  <ItemGroup
-    Condition="$(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or (('$(Platform)' == 'iPhone') OR ('$(RuntimeIdentifier)' == 'ios') OR $(RuntimeIdentifier.StartsWith('ios-')) OR $(RuntimeIdentifier.StartsWith('ios.'))) or $(TargetFramework.Contains('-maccatalyst')) == true or (('$(Platform)' == 'iPhoneSimulator') OR $(RuntimeIdentifier.StartsWith('iossimulator')))">
-    <MauiAsset Include="$(MSBuildThisFileDirectory)\ggml-metal.metal" LogicalName="ggml-metal.metal" />
-  </ItemGroup>
-
-  <!-- Metal Copy For MacOS -->
-  <ItemGroup Condition="$(TargetFramework.Contains('-macos')) == true or $(TargetFramework.Contains('-')) == false">
-    <None Visible="false" Include="$(MSBuildThisFileDirectory)\ggml-metal.metal">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>ggml-metal.metal</TargetPath>
-      <PublishFolderType>RootDirectory</PublishFolderType>
-    </None>
-  </ItemGroup>
 </Project>

--- a/tests/Whisper.net.Maui.Tests/Whisper.net.Maui.Tests.csproj
+++ b/tests/Whisper.net.Maui.Tests/Whisper.net.Maui.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Project="../../runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets" />
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -16,6 +16,9 @@
   <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
       AND $(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="$(USE_WHISPER_MAUI_TESTS) == ''
+      AND $(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets" />
 
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
+++ b/tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
@@ -5,6 +5,8 @@
 
   <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''"
           Project="../../runtimes/Whisper.net.Runtime/Whisper.net.Runtime.targets" />
+  <Import Condition="$(USE_WHISPER_NOAVX_TESTS) == ''"
+          Project="../../runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- add new Whisper.net.Runtime.Metal package for ggml-metal.metal
- depend on metal package from Runtime and Runtime.CoreML
- adjust build scripts and project imports for metal package

## Testing
- `dotnet test tests/Whisper.net.Tests/Whisper.net.Tests.csproj -f net8.0` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0affcb8483238d120d5f284391d6