### PR TITLE
Add support for dotnet 10

### DIFF
--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -120,6 +120,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            9.0.x
+            10.0.x
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
         with:

--- a/.github/workflows/dotnet-noavx.yml
+++ b/.github/workflows/dotnet-noavx.yml
@@ -31,6 +31,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Download Artifacts
         id: download-artifact

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   workflow_call:
-  
+
 
 env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -28,6 +28,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Download Artifacts
         id: download-artifact
@@ -41,21 +42,21 @@ jobs:
 
       - name: Run Dependency Checker
         run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
-        
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: csharp
           build-mode: manual
-    
+
       - name: Build
         run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
 
       - name: Test
         run: |
           dotnet test ./Whisper.net.sln --no-build  --logger "trx"
-          
+
       - name: Test Reporter
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
         if: success() || failure()    # run this step even if previous step failed
@@ -63,7 +64,7 @@ jobs:
           name: Whisper.net MacOs Test Results
           path: ./**/*.trx
           reporter: dotnet-trx
-          
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
@@ -76,7 +77,7 @@ jobs:
           name: test-results-macos
           path: ./**/*.trx
           retention-days: 7
-          
+
 
   dotnet-windows:
     runs-on: windows-latest
@@ -97,27 +98,27 @@ jobs:
         with:
           merge-multiple: true
           path: runtimes
-          
+
       - name: Restore dependencies
         run: dotnet restore ./Whisper.net.sln
-        
+
       - name: Run Dependency Checker
         run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
-        
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: csharp
           build-mode: manual
-    
+
       - name: Build
         run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
 
       - name: Test
         run: |
           dotnet test ./Whisper.net.sln --no-build --logger "trx"
-          
+
       - name: Test Reporter
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
         if: success() || failure()    # run this step even if previous step failed
@@ -138,7 +139,7 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:csharp"
-          
+
   dotnet-linux:
     runs-on: ubuntu-latest
 
@@ -158,20 +159,20 @@ jobs:
         with:
           merge-multiple: true
           path: runtimes
-          
+
       - name: Restore dependencies
         run: dotnet restore ./Whisper.net.sln
-        
+
       - name: Run Dependency Checker
         run: dotnet run --project ./tools/WhisperNetDependencyChecker/WhisperNetDependencyChecker.csproj
-        
+
       - name: Build
         run: dotnet build ./Whisper.net.sln --no-restore -warnaserror
 
       - name: Test
         run: |
           dotnet test ./Whisper.net.sln --no-build --logger "trx"
-                        
+
       - name: Test Reporter
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
         if: success() || failure()    # run this step even if previous step failed
@@ -187,4 +188,4 @@ jobs:
           name: test-results-linux
           path: ./**/*.trx
           retention-days: 7
-        
+

--- a/.github/workflows/pack-all.yml
+++ b/.github/workflows/pack-all.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Download Artifacts
         id: download-artifact

--- a/.github/workflows/push-all.yml
+++ b/.github/workflows/push-all.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Download Artifacts
         id: download-artifact

--- a/Whisper.net/Whisper.net.csproj
+++ b/Whisper.net/Whisper.net.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <!--<PropertyGroup>
@@ -30,7 +30,7 @@
 
   <PropertyGroup Condition="$(USE_WHISPER_MAUI) != ''">
     <TargetFrameworks>
-      net8.0;net9.0;netstandard2.0;net8.0-ios;net8.0-tvos;net8.0-maccatalyst;net8.0-android;net9.0-ios;net9.0-tvos;net9.0-maccatalyst;net9.0-android
+      net8.0;net9.0;net10.0;netstandard2.0;net9.0-ios;net9.0-tvos;net9.0-maccatalyst;net9.0-android;net10.0-ios;net10.0-tvos;net10.0-maccatalyst;net10.0-android
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Whisper.net.Maui.Tests/Whisper.net.Maui.Tests.csproj
+++ b/tests/Whisper.net.Maui.Tests/Whisper.net.Maui.Tests.csproj
@@ -3,8 +3,8 @@
   <Import Project="../../runtimes/Whisper.net.Runtime.Metal/Whisper.net.Runtime.Metal.targets" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
-		
+		<TargetFrameworks>net10.0-android;net10.0-ios</TargetFrameworks>
+
 		<!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
 		When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
@@ -85,5 +85,5 @@
 	  <ProjectReference Include="..\..\Whisper.net\Whisper.net.csproj" />
 	  <ProjectReference Include="..\Whisper.net.Tests\Whisper.net.Tests.csproj" />
 	</ItemGroup>
-  
+
 </Project>

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -17,7 +17,7 @@
 		<Nullable>enable</Nullable>
 		<LangVersion>13</LangVersion>
 		<IsTestProject>true</IsTestProject>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <NoWarn>xUnit1041</NoWarn>
 	</PropertyGroup>
 
@@ -36,7 +36,7 @@
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>
-      net8.0;net9.0;net48;
+      net8.0;net9.0;net10.0;net48;
     </TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Adding dedicated support for dotnet10 (works currently in backwards compatible way for net9 targeting, but in order to be able to use newer APIs, we will need to upgrade).