### PR TITLE
[CI] Increase ios tests timeouts

### DIFF
--- a/.github/workflows/dotnet-maui.yml
+++ b/.github/workflows/dotnet-maui.yml
@@ -145,7 +145,7 @@ jobs:
         run: xharness apple simulators list
 
       - name: run ios tests
-        run: xharness apple test --app=./maui-build-artifacts/net10.0-ios/iossimulator-arm64/Whisper.net.Maui.Tests.app --output-directory=./test-results/ios --target=ios-simulator-64 --device="iPhone 16"
+        run: xharness apple test --app=./maui-build-artifacts/net10.0-ios/iossimulator-arm64/Whisper.net.Maui.Tests.app --output-directory=./test-results/ios --target=ios-simulator-64 --device="iPhone 16" --timeout "00:30:00"        
 
       - name: Upload Maui iOS xharness test results
         if: ${{ always() }}


### PR DESCRIPTION
ios tests are flaky because they take ~15 mins and the default xharness timeout is 15 minutes. Doubled it to 30 to ensure that the tests will pass all the time.