### PR TITLE
Removing net48 tests on the host with no avx.

### DIFF
--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -34,7 +34,7 @@
 	</ItemGroup>
 
 
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) AND $(USE_WHISPER_NOAVX_TESTS) == ''">
     <TargetFrameworks>
       net9.0;net10.0;net48;
     </TargetFrameworks>


### PR DESCRIPTION
Will keep them on avx host, but they are too expensive for the non-avx host (it is the slowest workflow).