### PR TITLE
use error levels from ggml library

### DIFF
--- a/Whisper.net/Internals/Native/Data.cs
+++ b/Whisper.net/Internals/Native/Data.cs
@@ -63,9 +63,9 @@ internal struct WhisperVadParams
 
 internal enum GgmlLogLevel
 {
-    Error = 2,
+    Info = 2,
     Warning = 3,
-    Info = 4,
+    Error = 4,
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
according to https://github.com/ggml-org/whisper.cpp/blob/19ceec8eac980403b714d603e5ca31653cd42a3f/ggml/include/ggml.h#L612
values for log level error and info are reversed