### PR TITLE
expose whisper_lang_id() function

### DIFF
--- a/Whisper.net/Internals/Native/INativeWhisper.cs
+++ b/Whisper.net/Internals/Native/INativeWhisper.cs
@@ -47,6 +47,9 @@ internal interface INativeWhisper : IDisposable
     public delegate int whisper_lang_max_id();
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public delegate int whisper_lang_id(IntPtr lang);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public delegate int whisper_lang_auto_detect_with_state(IntPtr context, IntPtr state, int offset_ms, int n_threads, IntPtr lang_probs);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
@@ -95,6 +98,7 @@ internal interface INativeWhisper : IDisposable
     whisper_full_n_tokens_from_state Whisper_Full_N_Tokens_From_State { get; }
     whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State { get; }
     whisper_lang_max_id Whisper_Lang_Max_Id { get; }
+    whisper_lang_id Whisper_Lang_Id { get; }
     whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State { get; }
     whisper_pcm_to_mel_with_state Whisper_PCM_To_Mel_With_State { get; }
     whisper_lang_str Whisper_Lang_Str { get; }

--- a/Whisper.net/Internals/Native/Implementations/DllImportsNativeLibWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/DllImportsNativeLibWhisper.cs
@@ -50,6 +50,9 @@ internal class DllImportsNativeLibWhisper : INativeWhisper
     private static extern int whisper_lang_max_id();
 
     [DllImport(NativeConstants.LibWhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int whisper_lang_id(IntPtr lang);
+
+    [DllImport(NativeConstants.LibWhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int whisper_lang_auto_detect_with_state(IntPtr context, IntPtr state, int offset_ms, int n_threads, IntPtr lang_probs);
 
     [DllImport(NativeConstants.LibWhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -110,6 +113,8 @@ internal class DllImportsNativeLibWhisper : INativeWhisper
     public INativeWhisper.whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State => whisper_full_get_token_p_from_state;
 
     public INativeWhisper.whisper_lang_max_id Whisper_Lang_Max_Id => whisper_lang_max_id;
+
+    public INativeWhisper.whisper_lang_id Whisper_Lang_Id => whisper_lang_id;
 
     public INativeWhisper.whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State => whisper_lang_auto_detect_with_state;
 

--- a/Whisper.net/Internals/Native/Implementations/DllImportsNativeWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/DllImportsNativeWhisper.cs
@@ -50,6 +50,9 @@ internal class DllImportsNativeWhisper : INativeWhisper
     private static extern int whisper_lang_max_id();
 
     [DllImport(NativeConstants.WhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int whisper_lang_id(IntPtr lang);
+
+    [DllImport(NativeConstants.WhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int whisper_lang_auto_detect_with_state(IntPtr context, IntPtr state, int offset_ms, int n_threads, IntPtr lang_probs);
 
     [DllImport(NativeConstants.WhisperLibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -110,6 +113,8 @@ internal class DllImportsNativeWhisper : INativeWhisper
     public INativeWhisper.whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State => whisper_full_get_token_p_from_state;
 
     public INativeWhisper.whisper_lang_max_id Whisper_Lang_Max_Id => whisper_lang_max_id;
+
+    public INativeWhisper.whisper_lang_id Whisper_Lang_Id => whisper_lang_id;
 
     public INativeWhisper.whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State => whisper_lang_auto_detect_with_state;
 

--- a/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/LibraryImportInternalWhisper.cs
@@ -50,6 +50,9 @@ internal partial class LibraryImportInternalWhisper : INativeWhisper
     private static partial int whisper_lang_max_id();
 
     [LibraryImport(NativeConstants.InternalLibraryName)]
+    private static partial int whisper_lang_id(IntPtr lang);
+
+    [LibraryImport(NativeConstants.InternalLibraryName)]
     private static partial int whisper_lang_auto_detect_with_state(IntPtr context, IntPtr state, int offset_ms, int n_threads, IntPtr lang_probs);
 
     [LibraryImport(NativeConstants.InternalLibraryName)]
@@ -110,6 +113,8 @@ internal partial class LibraryImportInternalWhisper : INativeWhisper
     public INativeWhisper.whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State => whisper_full_get_token_p_from_state;
 
     public INativeWhisper.whisper_lang_max_id Whisper_Lang_Max_Id => whisper_lang_max_id;
+
+    public INativeWhisper.whisper_lang_id Whisper_Lang_Id => whisper_lang_id;
 
     public INativeWhisper.whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State => whisper_lang_auto_detect_with_state;
 

--- a/Whisper.net/Internals/Native/Implementations/LibraryImportLibWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/LibraryImportLibWhisper.cs
@@ -51,6 +51,9 @@ internal partial class LibraryImportLibWhisper : INativeWhisper
     private static partial int whisper_lang_max_id();
 
     [LibraryImport(NativeConstants.LibWhisperLibraryName)]
+    private static partial int whisper_lang_id(IntPtr lang);
+
+    [LibraryImport(NativeConstants.LibWhisperLibraryName)]
     private static partial int whisper_lang_auto_detect_with_state(IntPtr context, IntPtr state, int offset_ms, int n_threads, IntPtr lang_probs);
 
     [LibraryImport(NativeConstants.LibWhisperLibraryName)]
@@ -111,6 +114,8 @@ internal partial class LibraryImportLibWhisper : INativeWhisper
     public INativeWhisper.whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State => whisper_full_get_token_p_from_state;
 
     public INativeWhisper.whisper_lang_max_id Whisper_Lang_Max_Id => whisper_lang_max_id;
+
+    public INativeWhisper.whisper_lang_id Whisper_Lang_Id => whisper_lang_id;
 
     public INativeWhisper.whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State => whisper_lang_auto_detect_with_state;
 

--- a/Whisper.net/Internals/Native/Implementations/NativeLibraryWhisper.cs
+++ b/Whisper.net/Internals/Native/Implementations/NativeLibraryWhisper.cs
@@ -25,6 +25,7 @@ internal class NativeLibraryWhisper : INativeWhisper
         Whisper_Full_N_Tokens_From_State = Marshal.GetDelegateForFunctionPointer<whisper_full_n_tokens_from_state>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_full_n_tokens_from_state)));
         Whisper_Full_Get_Token_P_From_State = Marshal.GetDelegateForFunctionPointer<whisper_full_get_token_p_from_state>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_full_get_token_p_from_state)));
         Whisper_Lang_Max_Id = Marshal.GetDelegateForFunctionPointer<whisper_lang_max_id>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_lang_max_id)));
+        Whisper_Lang_Id = Marshal.GetDelegateForFunctionPointer<whisper_lang_id>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_lang_id)));
         Whisper_Lang_Auto_Detect_With_State = Marshal.GetDelegateForFunctionPointer<whisper_lang_auto_detect_with_state>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_lang_auto_detect_with_state)));
         Whisper_PCM_To_Mel_With_State = Marshal.GetDelegateForFunctionPointer<whisper_pcm_to_mel_with_state>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_pcm_to_mel_with_state)));
         Whisper_Lang_Str = Marshal.GetDelegateForFunctionPointer<whisper_lang_str>(NativeLibrary.GetExport(whisperLibraryHandle, nameof(whisper_lang_str)));
@@ -66,6 +67,8 @@ internal class NativeLibraryWhisper : INativeWhisper
     public whisper_full_get_token_p_from_state Whisper_Full_Get_Token_P_From_State { get; }
 
     public whisper_lang_max_id Whisper_Lang_Max_Id { get; }
+
+    public whisper_lang_id Whisper_Lang_Id { get; }
 
     public whisper_lang_auto_detect_with_state Whisper_Lang_Auto_Detect_With_State { get; }
 


### PR DESCRIPTION
expose a whisper.cpp function to get the id of a language or to check for an existing language.
I use it in my branch, but if you do not find useful, then reject the pull request.