### PR TITLE
fix off by one error language prob array

### DIFF
--- a/Whisper.net/WhisperProcessor.cs
+++ b/Whisper.net/WhisperProcessor.cs
@@ -107,7 +107,7 @@ public sealed class WhisperProcessor : IAsyncDisposable, IDisposable
     /// <returns></returns>
     public unsafe (string? language, float probability) DetectLanguageWithProbability(ReadOnlySpan<float> samples)
     {
-        var probs = new float[nativeWhisper.Whisper_Lang_Max_Id()];
+        var probs = new float[nativeWhisper.Whisper_Lang_Max_Id() + 1];
 
         fixed (float* pData = probs)
         {


### PR DESCRIPTION
whisper model supports 100 languages numbered from 0 to 99, so we need space for max-id (99) + 1 elements.
fixes potential crash when language detected is "yue" (with id 99)