### PR TITLE
Add forced runtime library override

### DIFF
--- a/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
@@ -85,24 +85,23 @@ public static class NativeLibraryLoader
 
         string? lastError = null;
 
-        var forcedRuntimeLibrary = RuntimeOptions.ForcedRuntimeLibrary;
-        IReadOnlyList<RuntimeLibrary> runtimeLibraryOrder = forcedRuntimeLibrary.HasValue
-            ? [forcedRuntimeLibrary.Value]
-            : RuntimeOptions.RuntimeLibraryOrder.ToList();
+        var runtimeSelection = RuntimeLibrarySelector.Select(
+            RuntimeOptions.ForcedRuntimeLibrary,
+            RuntimeOptions.RuntimeLibraryOrder);
 
-        if (forcedRuntimeLibrary.HasValue)
+        if (runtimeSelection.BypassCompatibilityChecks)
         {
             WhisperLogger.Log(WhisperLogLevel.Warning,
-                $"Runtime {forcedRuntimeLibrary.Value} was forced. Automatic runtime compatibility checks will be bypassed.");
+                $"Runtime {runtimeSelection.RuntimeLibraryOrder[0]} was forced. Automatic runtime compatibility checks will be bypassed.");
         }
 
-        var availableRuntimes = GetRuntimePaths(architecture, platform, runtimeLibraryOrder).ToList();
+        var availableRuntimes = GetRuntimePaths(architecture, platform, runtimeSelection.RuntimeLibraryOrder).ToList();
         var availableRuntimeTypes = availableRuntimes.Select(x => x.RuntimeLibrary).ToList();
 
         foreach (var (runtimePath, runtimeLibrary) in availableRuntimes)
         {
-            if (!IsRuntimeSupported(runtimeLibrary, platform, architecture, availableRuntimeTypes,
-                    forcedRuntimeLibrary))
+            if (!runtimeSelection.BypassCompatibilityChecks
+                && !IsRuntimeSupported(runtimeLibrary, platform, architecture, availableRuntimeTypes))
             {
                 continue;
             }
@@ -195,14 +194,9 @@ public static class NativeLibraryLoader
         return Path.Combine(runtimePath, libraryFileName);
     }
 
-    internal static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, string architecture,
-        List<RuntimeLibrary> runtimeLibraries, RuntimeLibrary? forcedRuntimeLibrary = null)
+    private static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, string architecture,
+        List<RuntimeLibrary> runtimeLibraries)
     {
-        if (forcedRuntimeLibrary == runtime)
-        {
-            return true;
-        }
-
         WhisperLogger.Log(WhisperLogLevel.Debug,
             $"Checking if runtime {runtime} is supported on the platform: {platform}");
 #if !NETSTANDARD

--- a/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
+++ b/Whisper.net/LibraryLoader/NativeLibraryLoader.cs
@@ -85,12 +85,24 @@ public static class NativeLibraryLoader
 
         string? lastError = null;
 
-        var availableRuntimes = GetRuntimePaths(architecture, platform).ToList();
+        var forcedRuntimeLibrary = RuntimeOptions.ForcedRuntimeLibrary;
+        IReadOnlyList<RuntimeLibrary> runtimeLibraryOrder = forcedRuntimeLibrary.HasValue
+            ? [forcedRuntimeLibrary.Value]
+            : RuntimeOptions.RuntimeLibraryOrder.ToList();
+
+        if (forcedRuntimeLibrary.HasValue)
+        {
+            WhisperLogger.Log(WhisperLogLevel.Warning,
+                $"Runtime {forcedRuntimeLibrary.Value} was forced. Automatic runtime compatibility checks will be bypassed.");
+        }
+
+        var availableRuntimes = GetRuntimePaths(architecture, platform, runtimeLibraryOrder).ToList();
         var availableRuntimeTypes = availableRuntimes.Select(x => x.RuntimeLibrary).ToList();
 
         foreach (var (runtimePath, runtimeLibrary) in availableRuntimes)
         {
-            if (!IsRuntimeSupported(runtimeLibrary, platform, architecture, availableRuntimeTypes))
+            if (!IsRuntimeSupported(runtimeLibrary, platform, architecture, availableRuntimeTypes,
+                    forcedRuntimeLibrary))
             {
                 continue;
             }
@@ -183,9 +195,14 @@ public static class NativeLibraryLoader
         return Path.Combine(runtimePath, libraryFileName);
     }
 
-    private static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, string architecture,
-        List<RuntimeLibrary> runtimeLibraries)
+    internal static bool IsRuntimeSupported(RuntimeLibrary runtime, string platform, string architecture,
+        List<RuntimeLibrary> runtimeLibraries, RuntimeLibrary? forcedRuntimeLibrary = null)
     {
+        if (forcedRuntimeLibrary == runtime)
+        {
+            return true;
+        }
+
         WhisperLogger.Log(WhisperLogLevel.Debug,
             $"Checking if runtime {runtime} is supported on the platform: {platform}");
 #if !NETSTANDARD
@@ -231,7 +248,7 @@ public static class NativeLibraryLoader
     }
 
     private static IEnumerable<(string RuntimePath, RuntimeLibrary RuntimeLibrary)> GetRuntimePaths(string architecture,
-        string platform)
+        string platform, IReadOnlyList<RuntimeLibrary> runtimeLibraryOrder)
     {
         var assemblyLocation = typeof(NativeLibraryLoader).Assembly.Location;
         // NetFramework and Mono will crash if we try to get the directory of an empty string.
@@ -242,7 +259,7 @@ public static class NativeLibraryLoader
             GetSafeDirectoryName(Environment.GetCommandLineArgs().FirstOrDefault()),
         }.Where(it => !string.IsNullOrEmpty(it)).Distinct();
 
-        foreach (var library in RuntimeOptions.RuntimeLibraryOrder)
+        foreach (var library in runtimeLibraryOrder)
         {
             foreach (var assemblySearchPath in assemblySearchPaths)
             {

--- a/Whisper.net/LibraryLoader/RuntimeLibrarySelector.cs
+++ b/Whisper.net/LibraryLoader/RuntimeLibrarySelector.cs
@@ -1,0 +1,28 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+namespace Whisper.net.LibraryLoader;
+
+internal sealed class RuntimeLibrarySelection
+{
+    internal RuntimeLibrarySelection(IReadOnlyList<RuntimeLibrary> runtimeLibraryOrder,
+        bool bypassCompatibilityChecks)
+    {
+        RuntimeLibraryOrder = runtimeLibraryOrder;
+        BypassCompatibilityChecks = bypassCompatibilityChecks;
+    }
+
+    internal IReadOnlyList<RuntimeLibrary> RuntimeLibraryOrder { get; }
+
+    internal bool BypassCompatibilityChecks { get; }
+}
+
+internal static class RuntimeLibrarySelector
+{
+    internal static RuntimeLibrarySelection Select(RuntimeLibrary? forcedRuntimeLibrary,
+        IReadOnlyList<RuntimeLibrary> preferredRuntimeLibraryOrder)
+    {
+        return forcedRuntimeLibrary.HasValue
+            ? new RuntimeLibrarySelection([forcedRuntimeLibrary.Value], bypassCompatibilityChecks: true)
+            : new RuntimeLibrarySelection(preferredRuntimeLibraryOrder.ToList(), bypassCompatibilityChecks: false);
+    }
+}

--- a/Whisper.net/LibraryLoader/RuntimeOptions.cs
+++ b/Whisper.net/LibraryLoader/RuntimeOptions.cs
@@ -26,6 +26,24 @@ public static class RuntimeOptions
     public static List<RuntimeLibrary> RuntimeLibraryOrder { get; set; } = defaultRuntimeOrder;
 
     /// <summary>
+    /// Gets or sets the runtime library that should be loaded without performing compatibility checks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, <see cref="RuntimeLibraryOrder"/> is ignored, only the specified runtime is considered, and
+    /// automatic compatibility checks such as CPU instruction-set and CUDA availability detection are bypassed.
+    /// Native library path resolution and loading are still performed normally.
+    /// </para>
+    /// <para>
+    /// Use this option only when the application has determined that the runtime is compatible with the current
+    /// hardware and software environment. Forcing an incompatible runtime can cause native library loading failures
+    /// or process crashes due to unsupported CPU instructions.
+    /// </para>
+    /// <para>This value must be set before any <seealso cref="WhisperFactory"/> is created.</para>
+    /// </remarks>
+    public static RuntimeLibrary? ForcedRuntimeLibrary { get; set; }
+
+    /// <summary>
     /// Gets or sets the library that was loaded by the runtime.
     /// </summary>
     /// <remarks>

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ The following order of priority will be used by default:
 
 The loader automatically probes the CUDA runtimes in this order and validates the installed driver via `cudaRuntimeGetVersion`, so machines with only CUDA 12 drivers will transparently fall back to `Whisper.net.Runtime.Cuda12`.
 
-To change the order or force a specific runtime, set the `RuntimeLibraryOrder` on the `RuntimeOptions`:
+To change the preferred runtime order, set `RuntimeLibraryOrder` on `RuntimeOptions`:
 
 ```csharp
 RuntimeOptions.RuntimeLibraryOrder =
@@ -210,6 +210,16 @@ RuntimeOptions.RuntimeLibraryOrder =
     RuntimeLibrary.Cpu
 ];
 ```
+
+Setting `RuntimeLibraryOrder` changes the preferred order, but compatibility checks are still performed before a runtime is loaded. If your application performs its own hardware and software detection, you can force a runtime and bypass those checks:
+
+```csharp
+RuntimeOptions.ForcedRuntimeLibrary = RuntimeLibrary.Cpu;
+```
+
+Set `ForcedRuntimeLibrary` before creating any `WhisperFactory`. Only the specified runtime will be considered; native library path resolution and loading will still occur normally, but automatic checks such as CPU instruction-set and CUDA availability detection will be skipped. The application is responsible for ensuring the selected runtime is compatible. Forcing an incompatible runtime can cause native library loading failures or process crashes due to unsupported CPU instructions.
+
+This override can also be used by Native AOT applications that perform their own runtime hardware detection, without raising the managed application's instruction-set baseline.
 
 ### Pluggable native runtimes
 - Whisper.net can run with any compatible compilation of the native whisper.cpp libraries; the package Whisper.net.Runtime is just one of the possible builds we publish.

--- a/tests/Whisper.net.Tests/NativeLibraryLoaderTests.cs
+++ b/tests/Whisper.net.Tests/NativeLibraryLoaderTests.cs
@@ -15,15 +15,27 @@ public class NativeLibraryLoaderTests
     [InlineData(RuntimeLibrary.CoreML)]
     [InlineData(RuntimeLibrary.OpenVino)]
     [InlineData(RuntimeLibrary.CpuNoAvx)]
-    public void IsRuntimeSupported_WhenRuntimeIsForced_ShouldBypassCompatibilityChecks(RuntimeLibrary runtime)
+    public void Select_WhenRuntimeIsForced_ShouldSelectOnlyThatRuntimeAndBypassCompatibilityChecks(
+        RuntimeLibrary runtime)
     {
-        var isSupported = NativeLibraryLoader.IsRuntimeSupported(
-            runtime,
-            platform: "win",
-            architecture: "x64",
-            runtimeLibraries: [],
-            forcedRuntimeLibrary: runtime);
+        var selection = RuntimeLibrarySelector.Select(
+            forcedRuntimeLibrary: runtime,
+            preferredRuntimeLibraryOrder: [RuntimeLibrary.Cuda, RuntimeLibrary.Cpu]);
 
-        Assert.True(isSupported);
+        Assert.Equal([runtime], selection.RuntimeLibraryOrder);
+        Assert.True(selection.BypassCompatibilityChecks);
+    }
+
+    [Fact]
+    public void Select_WhenRuntimeIsNotForced_ShouldPreservePreferredOrderAndCompatibilityChecks()
+    {
+        RuntimeLibrary[] preferredOrder = [RuntimeLibrary.Cuda, RuntimeLibrary.Cpu];
+
+        var selection = RuntimeLibrarySelector.Select(
+            forcedRuntimeLibrary: null,
+            preferredRuntimeLibraryOrder: preferredOrder);
+
+        Assert.Equal(preferredOrder, selection.RuntimeLibraryOrder);
+        Assert.False(selection.BypassCompatibilityChecks);
     }
 }

--- a/tests/Whisper.net.Tests/NativeLibraryLoaderTests.cs
+++ b/tests/Whisper.net.Tests/NativeLibraryLoaderTests.cs
@@ -1,0 +1,29 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Whisper.net.LibraryLoader;
+using Xunit;
+
+namespace Whisper.net.Tests;
+
+public class NativeLibraryLoaderTests
+{
+    [Theory]
+    [InlineData(RuntimeLibrary.Cpu)]
+    [InlineData(RuntimeLibrary.Cuda)]
+    [InlineData(RuntimeLibrary.Cuda12)]
+    [InlineData(RuntimeLibrary.Vulkan)]
+    [InlineData(RuntimeLibrary.CoreML)]
+    [InlineData(RuntimeLibrary.OpenVino)]
+    [InlineData(RuntimeLibrary.CpuNoAvx)]
+    public void IsRuntimeSupported_WhenRuntimeIsForced_ShouldBypassCompatibilityChecks(RuntimeLibrary runtime)
+    {
+        var isSupported = NativeLibraryLoader.IsRuntimeSupported(
+            runtime,
+            platform: "win",
+            architecture: "x64",
+            runtimeLibraries: [],
+            forcedRuntimeLibrary: runtime);
+
+        Assert.True(isSupported);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `RuntimeOptions.ForcedRuntimeLibrary` for consumers that perform their own hardware and software compatibility detection.
- When set, consider only the selected runtime and bypass the built-in CPU instruction-set and CUDA availability checks.
- Continue to use the normal native-library path resolution and loading process.
- Document the override, its Native AOT use case, and the risks of forcing an incompatible runtime.

## Motivation

Under Native AOT, properties such as `Avx.IsSupported`, `Avx2.IsSupported`, and `Fma.IsSupported` reflect the application's compile-time instruction-set baseline. With the default baseline they can therefore report `false` on hardware that does support those instructions, causing Whisper.net to reject the regular CPU runtime.

Rather than maintain a separate CPUID-based feature detector, this change lets applications that know their deployment environment—or already have their own detection logic—explicitly select the runtime:

```csharp
RuntimeOptions.ForcedRuntimeLibrary = RuntimeLibrary.Cpu;

using var factory = WhisperFactory.FromPath(modelPath);
```

The option must be set before creating any `WhisperFactory`.

## Behavior

When `ForcedRuntimeLibrary` is set:

- `RuntimeLibraryOrder` is ignored.
- Only the forced runtime's directory is searched.
- Runtime compatibility probes are skipped.
- Native dependencies and the Whisper library are still resolved and loaded normally.
- No alternative runtime is selected if loading fails.
- A warning is logged to make the bypass visible.

The consumer is responsible for compatibility. Forcing an incompatible runtime may fail native loading or crash the process due to unsupported CPU instructions.

## Validation

- Added coverage confirming that compatibility checks are bypassed for every `RuntimeLibrary` value.
- Verified the library builds for .NET 8, .NET 9, .NET 10, and .NET Standard 2.0.
- Focused tests pass on .NET 10.

Fixes #538