### PR TITLE
Automate preview native runtime restoration and caching

### DIFF
--- a/.github/skills/run-dotnet-tests-with-preview-nativelibs/SKILL.md
+++ b/.github/skills/run-dotnet-tests-with-preview-nativelibs/SKILL.md
@@ -30,34 +30,28 @@ Example release:
 https://github.com/sandrohanea/whisper.net/releases/tag/preview-nativelibs-f24588a
 ```
 
-## PowerShell workflow
+## Restore workflow
 
-Run from the repository root:
-
-```powershell
-$commit = git rev-parse --short=7 HEAD:whisper.cpp
-$tag = "preview-nativelibs-$commit"
-gh release download $tag --repo sandrohanea/whisper.net --pattern native-runtimes.zip --clobber
-Expand-Archive .\native-runtimes.zip -DestinationPath . -Force
-Copy-Item .\runtime-artifacts\* .\runtimes\ -Recurse -Force
-Remove-Item .\runtime-artifacts -Recurse -Force
-Remove-Item .\native-runtimes.zip
-dotnet restore .\Whisper.net.slnx
-dotnet build .\Whisper.net.slnx --no-restore -warnaserror
-dotnet test .\Whisper.net.slnx --no-build --logger "trx"
-```
-
-## Bash workflow
-
-Run from the repository root:
+Run from the repository root on Windows, macOS, or Linux:
 
 ```bash
-commit="$(git rev-parse --short=7 HEAD:whisper.cpp)"
-tag="preview-nativelibs-$commit"
-gh release download "$tag" --repo sandrohanea/whisper.net --pattern native-runtimes.zip --clobber
-unzip -o native-runtimes.zip
-cp -R runtime-artifacts/* runtimes/
-rm -rf runtime-artifacts native-runtimes.zip
+dotnet run --project tools/RestoreNativeLibraries
+```
+
+The restorer derives the release tag from the pinned `whisper.cpp` gitlink. It caches each revision under `.whisper/native-runtimes/` in the primary checkout so linked worktrees do not download the same release repeatedly. Concurrent processes use a cache lock and publish completed entries atomically.
+
+Useful diagnostics and overrides:
+
+```bash
+dotnet run --project tools/RestoreNativeLibraries -- --check
+dotnet run --project tools/RestoreNativeLibraries -- --force
+dotnet run --project tools/RestoreNativeLibraries -- --no-cache
+dotnet run --project tools/RestoreNativeLibraries -- --cache-dir <path>
+```
+
+After the runtimes are available:
+
+```bash
 dotnet restore ./Whisper.net.slnx
 dotnet build ./Whisper.net.slnx --no-restore -warnaserror
 dotnet test ./Whisper.net.slnx --no-build --logger "trx"
@@ -65,10 +59,10 @@ dotnet test ./Whisper.net.slnx --no-build --logger "trx"
 
 ## Test model handling
 
-The preview native libs release contains native runtime artifacts, not necessarily test model files. Do not set `WHISPER_TEST_MODEL_PATH` to `runtimes/` unless the required `ggml-*.bin` model files are present there. Without that variable, the tests download models through the normal test fixture path.
+The release can contain test-model artifacts in addition to native runtimes. The restorer intentionally installs only `Whisper.net.Runtime*` directories; model population remains a separate workflow. Do not set `WHISPER_TEST_MODEL_PATH` to `runtimes/`. Without that variable, the tests download models through the normal test fixture path.
 
 ## Repository hygiene
 
 - Treat downloaded native runtimes as local test inputs, not source changes.
 - Do not commit copied binaries from `native-runtimes.zip` unless the task explicitly asks to update runtime artifacts.
-- Remove temporary `native-runtimes.zip` and `runtime-artifacts/` files after unpacking.
+- The restorer cleans up temporary archives and extraction directories automatically.

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ bld/
 .test-models/
 test-models/
 
+# Shared development caches (including preview native runtimes)
+.whisper/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,12 @@ Keep the submodule on the revision pinned in `.gitmodules`. When proposing updat
 Most features depend on native runtimes placed under `runtimes/Whisper.net.Runtime*`. If you do not want to build every flavour locally, download the prebuilt artifacts:
 
 ```bash
-wget https://github.com/sandrohanea/whisper.net/releases/download/preview-nativelibs-41fc9de/native-runtimes.zip
-unzip native-runtimes.zip
-cp runtime-artifacts/* runtimes -r
-rm -r runtime-artifacts
+dotnet run --project tools/RestoreNativeLibraries
 ```
 
-The `Makefile` documents how to build each runtime manually. If you modify native code, re-run the relevant make targets (e.g. `make linux`, `make windows`, `make wasm`) and update the copied binaries in `runtimes/` accordingly.
+The restorer selects the preview release matching the pinned `whisper.cpp` revision. By default, it downloads and extracts each revision once under the primary checkout's `.whisper/native-runtimes/` cache, which is shared by all linked Git worktrees. It then copies the artifacts into the current worktree. Use `--check` to inspect the current state, `--force` to replace a damaged cache entry, or `--no-cache` to use a temporary download.
+
+Preview artifacts are only suitable for managed-only development. The `Makefile` documents how to build each runtime manually. If you modify native code, native build inputs, or runtime packaging, re-run the relevant make targets (e.g. `make linux`, `make windows`, `make wasm`) and update the copied binaries in `runtimes/` accordingly.
 
 ## Building the managed code
 Restore and build from the solution root:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Devcontainer (optional)
   - Optional: Vulkan/CUDA/OpenVINO tools if working on those runtimes
 - Cache nuget packages via a mapped host directory (e.g., /home/vscode/.nuget/packages) for faster restores.
 - Ensure submodules are initialized if you plan to build native code: git submodule update --init --recursive
-- Native runtime download: A devcontainer can include a bootstrap script to download the prebuilt native runtimes into ./runtimes for local testing. See below for a placeholder link.
+- Native runtime download: Run `dotnet run --project tools/RestoreNativeLibraries` to populate `./runtimes` from the preview release matching the pinned `whisper.cpp` revision. Linked Git worktrees share the download cache in the primary checkout's `.whisper/native-runtimes/` directory.
   - Link: TODO add link to repository devcontainer template (e.g., .devcontainer folder) once published.
 
 Editors and IDEs
@@ -38,6 +38,7 @@ Editors and IDEs
 
 Native runtime usage during development
 - Default: Projects resolve native libraries from the published NuGet runtime packages (Whisper.net.Runtime*). This is the easiest path for library and app development.
+- Managed tests in this repository: Run `dotnet run --project tools/RestoreNativeLibraries` once per worktree. The tool reuses its shared cache, and `--check`, `--force`, `--no-cache`, and `--cache-dir` provide diagnostics and cache control.
 - Local native builds: If you change native code and want to test locally, see the section “Building The Runtime” for build instructions. Ensure your output layout matches the expected runtimes folders (./runtimes/*) so the loader can probe them.
 
 MAUI/mobile tooling

--- a/Whisper.net.slnx
+++ b/Whisper.net.slnx
@@ -84,6 +84,10 @@
       <BuildType Solution="MinSizeRel|*" Project="Release" />
       <BuildType Solution="RelWithDebInfo|*" Project="Debug" />
     </Project>
+    <Project Path="tools/RestoreNativeLibraries/RestoreNativeLibraries.csproj">
+      <BuildType Solution="MinSizeRel|*" Project="Release" />
+      <BuildType Solution="RelWithDebInfo|*" Project="Release" />
+    </Project>
   </Folder>
   <Project Path="tests/Whisper.net.Tests/Whisper.net.Tests.csproj">
     <BuildType Solution="MinSizeRel|*" Project="Debug" />

--- a/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
+++ b/tests/Whisper.net.Tests/Whisper.net.Tests.csproj
@@ -49,6 +49,21 @@
 		<ProjectReference Include="..\..\Whisper.net\Whisper.net.csproj" />
 	</ItemGroup>
 
+  <Target Name="EnsureNativeRuntimesAreAvailable"
+          BeforeTargets="PrepareForBuild"
+          Condition="'$(DesignTimeBuild)' != 'true' AND '$(USE_WHISPER_MAUI_TESTS)' == ''">
+    <ItemGroup Condition="'$(USE_WHISPER_NOAVX_TESTS)' != ''">
+      <_WhisperNativeRuntimeFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\Whisper.net.Runtime.NoAvx\**\*"
+                                 Exclude="$(MSBuildThisFileDirectory)..\..\runtimes\Whisper.net.Runtime.NoAvx\*.targets" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(USE_WHISPER_NOAVX_TESTS)' == ''">
+      <_WhisperNativeRuntimeFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\Whisper.net.Runtime\**\*"
+                                 Exclude="$(MSBuildThisFileDirectory)..\..\runtimes\Whisper.net.Runtime\*.targets" />
+    </ItemGroup>
+    <Error Condition="'@(_WhisperNativeRuntimeFile)' == ''"
+           Text="Native runtimes are missing. Run 'dotnet run --project tools/RestoreNativeLibraries' from the repository root, then retry. Preview runtimes are only suitable for managed-only changes." />
+  </Target>
+
   <!-- Files cannot be copied without PublishFolderType on MAUI, and test data is embedded as MauiAsset there -->
 	<ItemGroup Condition="$(USE_WHISPER_MAUI_TESTS) == ''">
     <None Include="..\TestData\**">

--- a/tools/RestoreNativeLibraries/Program.cs
+++ b/tools/RestoreNativeLibraries/Program.cs
@@ -1,0 +1,402 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+
+const string RepositoryName = "sandrohanea/whisper.net";
+const string AssetName = "native-runtimes.zip";
+
+try
+{
+    var options = Options.Parse(args);
+    if (options.ShowHelp)
+    {
+        Options.PrintUsage();
+        return 0;
+    }
+
+    var repositoryRoot = options.RepositoryRoot is null
+        ? await RunGitAsync(Directory.GetCurrentDirectory(), "rev-parse", "--show-toplevel")
+        : Path.GetFullPath(options.RepositoryRoot);
+    var nativeCommit = await RunGitAsync(repositoryRoot, "rev-parse", "--short=7", "HEAD:whisper.cpp");
+    var tag = $"preview-nativelibs-{nativeCommit}";
+    var releaseUrl = $"https://github.com/{RepositoryName}/releases/download/{tag}/{AssetName}";
+    var runtimesDirectory = Path.Combine(repositoryRoot, "runtimes");
+    var cacheRoot = options.CacheDirectory is null
+        ? await GetDefaultCacheRootAsync(repositoryRoot)
+        : Path.GetFullPath(options.CacheDirectory);
+    var cacheEntry = Path.Combine(cacheRoot, nativeCommit);
+
+    Console.WriteLine($"Native runtimes: whisper.cpp {nativeCommit}");
+    Console.WriteLine(options.NoCache ? "Cache: disabled" : $"Cache: {cacheEntry}");
+
+    if (options.CheckOnly)
+    {
+        var cacheState = options.NoCache ? "disabled" : IsCompleteCacheEntry(cacheEntry) ? "ready" : "missing";
+        var installedFileCount = CountInstalledRuntimeFiles(runtimesDirectory);
+        Console.WriteLine($"Cache state: {cacheState}");
+        Console.WriteLine($"Installed runtime files: {installedFileCount}");
+        Console.WriteLine($"Release: {releaseUrl}");
+        return installedFileCount > 0 ? 0 : 1;
+    }
+
+    string artifactsDirectory;
+    string? temporaryDirectory = null;
+
+    if (options.NoCache)
+    {
+        temporaryDirectory = CreateTemporaryDirectory();
+        try
+        {
+            artifactsDirectory = await DownloadAndExtractAsync(releaseUrl, temporaryDirectory);
+        }
+        catch
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+            throw;
+        }
+        Console.WriteLine("Cache: bypassed");
+    }
+    else
+    {
+        if (!options.Force && IsCompleteCacheEntry(cacheEntry))
+        {
+            Console.WriteLine("Cache: hit");
+        }
+        else
+        {
+            Directory.CreateDirectory(cacheRoot);
+            var lockPath = Path.Combine(cacheRoot, $"{nativeCommit}.lock");
+            await using var cacheLock = await AcquireCacheLockAsync(lockPath);
+
+            if (options.Force && Directory.Exists(cacheEntry))
+            {
+                Directory.Delete(cacheEntry, recursive: true);
+            }
+
+            if (!IsCompleteCacheEntry(cacheEntry))
+            {
+                if (Directory.Exists(cacheEntry))
+                {
+                    Directory.Delete(cacheEntry, recursive: true);
+                }
+
+                var stagingDirectory = Path.Combine(cacheRoot, $".{nativeCommit}.partial-{Environment.ProcessId}-{Guid.NewGuid():N}");
+                try
+                {
+                    await DownloadAndExtractAsync(releaseUrl, stagingDirectory);
+                    await File.WriteAllTextAsync(
+                        Path.Combine(stagingDirectory, ".complete"),
+                        $"tag={tag}{Environment.NewLine}url={releaseUrl}{Environment.NewLine}");
+                    Directory.Move(stagingDirectory, cacheEntry);
+                }
+                finally
+                {
+                    if (Directory.Exists(stagingDirectory))
+                    {
+                        Directory.Delete(stagingDirectory, recursive: true);
+                    }
+                }
+
+                Console.WriteLine("Cache: downloaded");
+            }
+            else
+            {
+                Console.WriteLine("Cache: filled by another restore process");
+            }
+        }
+
+        artifactsDirectory = Path.Combine(cacheEntry, "runtime-artifacts");
+    }
+
+    try
+    {
+        var copiedFileCount = CopyRuntimeArtifacts(artifactsDirectory, runtimesDirectory);
+        Console.WriteLine($"Installed {copiedFileCount} runtime files into {runtimesDirectory}");
+        return 0;
+    }
+    finally
+    {
+        if (temporaryDirectory is not null && Directory.Exists(temporaryDirectory))
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+}
+catch (CommandLineException exception)
+{
+    Console.Error.WriteLine(exception.Message);
+    Console.Error.WriteLine();
+    Options.PrintUsage();
+    return 2;
+}
+catch (Exception exception)
+{
+    Console.Error.WriteLine($"Failed to restore native runtimes: {exception.Message}");
+    return 1;
+}
+
+static async Task<string> GetDefaultCacheRootAsync(string repositoryRoot)
+{
+    var commonGitDirectory = await RunGitAsync(
+        repositoryRoot,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir");
+    var commonGitDirectoryPath = Path.IsPathRooted(commonGitDirectory)
+        ? commonGitDirectory
+        : Path.GetFullPath(commonGitDirectory, repositoryRoot);
+    var primaryCheckout = Directory.GetParent(commonGitDirectoryPath)?.FullName
+        ?? throw new InvalidOperationException($"Cannot determine the primary checkout from '{commonGitDirectoryPath}'.");
+
+    return Path.Combine(primaryCheckout, ".whisper", "native-runtimes");
+}
+
+static async Task<string> RunGitAsync(string workingDirectory, params string[] arguments)
+{
+    var startInfo = new ProcessStartInfo("git")
+    {
+        WorkingDirectory = workingDirectory,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false
+    };
+    foreach (var argument in arguments)
+    {
+        startInfo.ArgumentList.Add(argument);
+    }
+
+    using var process = Process.Start(startInfo)
+        ?? throw new InvalidOperationException("Failed to start git. Ensure it is installed and available on PATH.");
+    var standardOutput = await process.StandardOutput.ReadToEndAsync();
+    var standardError = await process.StandardError.ReadToEndAsync();
+    await process.WaitForExitAsync();
+
+    if (process.ExitCode != 0)
+    {
+        throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed: {standardError.Trim()}");
+    }
+
+    return standardOutput.Trim();
+}
+
+static async Task<FileStream> AcquireCacheLockAsync(string lockPath)
+{
+    var waitingMessageWritten = false;
+    var timeoutAt = DateTime.UtcNow.AddMinutes(10);
+    while (true)
+    {
+        try
+        {
+            return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException) when (DateTime.UtcNow < timeoutAt)
+        {
+            if (!waitingMessageWritten)
+            {
+                Console.WriteLine("Cache: waiting for another restore process");
+                waitingMessageWritten = true;
+            }
+
+            await Task.Delay(500);
+        }
+    }
+}
+
+static async Task<string> DownloadAndExtractAsync(string releaseUrl, string destinationDirectory)
+{
+    Directory.CreateDirectory(destinationDirectory);
+    var archivePath = Path.Combine(destinationDirectory, AssetName);
+
+    using var httpClient = new HttpClient
+    {
+        Timeout = TimeSpan.FromMinutes(10)
+    };
+    httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("whisper.net-native-runtime-restorer/1.0");
+
+    for (var attempt = 1; ; attempt++)
+    {
+        try
+        {
+            Console.WriteLine($"Downloading {releaseUrl}");
+            using var response = await httpClient.GetAsync(releaseUrl, HttpCompletionOption.ResponseHeadersRead);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new InvalidOperationException(
+                    $"No preview native runtime release exists at {releaseUrl}. " +
+                    "Build the native runtimes when the pinned whisper.cpp revision or native build inputs have changed.");
+            }
+
+            response.EnsureSuccessStatusCode();
+            await using var archive = new FileStream(archivePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await response.Content.CopyToAsync(archive);
+            break;
+        }
+        catch (Exception exception) when (attempt < 4 && exception is HttpRequestException or TaskCanceledException)
+        {
+            var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
+            Console.WriteLine($"Download failed; retrying in {delay.TotalSeconds:0} second(s)");
+            await Task.Delay(delay);
+        }
+    }
+
+    var extractionDirectory = Path.Combine(destinationDirectory, "extracted");
+    ZipFile.ExtractToDirectory(archivePath, extractionDirectory);
+    File.Delete(archivePath);
+
+    var extractedArtifactsDirectory = Path.Combine(extractionDirectory, "runtime-artifacts");
+    ValidateArtifactsDirectory(extractedArtifactsDirectory);
+    var artifactsDirectory = Path.Combine(destinationDirectory, "runtime-artifacts");
+    Directory.Move(extractedArtifactsDirectory, artifactsDirectory);
+    Directory.Delete(extractionDirectory, recursive: true);
+    return artifactsDirectory;
+}
+
+static bool IsCompleteCacheEntry(string cacheEntry)
+{
+    var artifactsDirectory = Path.Combine(cacheEntry, "runtime-artifacts");
+    return File.Exists(Path.Combine(cacheEntry, ".complete")) && IsValidArtifactsDirectory(artifactsDirectory);
+}
+
+static void ValidateArtifactsDirectory(string artifactsDirectory)
+{
+    if (!IsValidArtifactsDirectory(artifactsDirectory))
+    {
+        throw new InvalidDataException(
+            $"The downloaded archive does not contain the expected runtime-artifacts/Whisper.net.Runtime layout.");
+    }
+}
+
+static bool IsValidArtifactsDirectory(string artifactsDirectory)
+{
+    var cpuRuntimeDirectory = Path.Combine(artifactsDirectory, "Whisper.net.Runtime");
+    return Directory.Exists(cpuRuntimeDirectory)
+        && Directory.EnumerateFiles(cpuRuntimeDirectory, "*", SearchOption.AllDirectories).Any();
+}
+
+static int CopyRuntimeArtifacts(string sourceDirectory, string destinationDirectory)
+{
+    var copiedFileCount = 0;
+    foreach (var runtimeDirectory in Directory.EnumerateDirectories(sourceDirectory, "Whisper.net.Runtime*"))
+    {
+        foreach (var sourceFile in Directory.EnumerateFiles(runtimeDirectory, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, sourceFile);
+            var destinationFile = Path.Combine(destinationDirectory, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+            File.Copy(sourceFile, destinationFile, overwrite: true);
+            copiedFileCount++;
+        }
+    }
+
+    return copiedFileCount;
+}
+
+static int CountInstalledRuntimeFiles(string runtimesDirectory)
+{
+    if (!Directory.Exists(runtimesDirectory))
+    {
+        return 0;
+    }
+
+    return Directory.EnumerateDirectories(runtimesDirectory, "Whisper.net.Runtime*")
+        .SelectMany(directory => Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+        .Count(file => !file.EndsWith(".targets", StringComparison.OrdinalIgnoreCase));
+}
+
+static string CreateTemporaryDirectory()
+{
+    var directory = Path.Combine(Path.GetTempPath(), $"whisper-native-runtimes-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(directory);
+    return directory;
+}
+
+internal sealed record Options(
+    bool CheckOnly,
+    bool Force,
+    bool NoCache,
+    bool ShowHelp,
+    string? CacheDirectory,
+    string? RepositoryRoot)
+{
+    public static Options Parse(string[] arguments)
+    {
+        var checkOnly = false;
+        var force = false;
+        var noCache = false;
+        var showHelp = false;
+        string? cacheDirectory = null;
+        string? repositoryRoot = null;
+
+        for (var index = 0; index < arguments.Length; index++)
+        {
+            switch (arguments[index])
+            {
+                case "--check":
+                    checkOnly = true;
+                    break;
+                case "--force":
+                    force = true;
+                    break;
+                case "--no-cache":
+                    noCache = true;
+                    break;
+                case "--cache-dir":
+                    cacheDirectory = ReadValue(arguments, ref index, "--cache-dir");
+                    break;
+                case "--repository":
+                    repositoryRoot = ReadValue(arguments, ref index, "--repository");
+                    break;
+                case "--help" or "-h":
+                    showHelp = true;
+                    break;
+                default:
+                    throw new CommandLineException($"Unknown option '{arguments[index]}'.");
+            }
+        }
+
+        if (noCache && cacheDirectory is not null)
+        {
+            throw new CommandLineException("--no-cache and --cache-dir cannot be used together.");
+        }
+
+        if (checkOnly && force)
+        {
+            throw new CommandLineException("--check and --force cannot be used together.");
+        }
+
+        return new Options(checkOnly, force, noCache, showHelp, cacheDirectory, repositoryRoot);
+    }
+
+    public static void PrintUsage()
+    {
+        Console.WriteLine(
+            """
+            Restore the preview native libraries matching the pinned whisper.cpp revision.
+
+            Usage:
+              dotnet run --project tools/RestoreNativeLibraries -- [options]
+
+            Options:
+              --check              Report cache and installation state without making changes.
+              --force              Redownload the matching cache entry.
+              --no-cache           Download to a temporary directory instead of using the shared cache.
+              --cache-dir <path>   Override the shared cache directory.
+              --repository <path>  Override the repository root (primarily useful for automation).
+              -h, --help           Show this help.
+            """);
+    }
+
+    private static string ReadValue(string[] arguments, ref int index, string option)
+    {
+        if (++index >= arguments.Length || string.IsNullOrWhiteSpace(arguments[index]))
+        {
+            throw new CommandLineException($"{option} requires a path.");
+        }
+
+        return arguments[index];
+    }
+}
+
+internal sealed class CommandLineException(string message) : Exception(message);

--- a/tools/RestoreNativeLibraries/RestoreNativeLibraries.csproj
+++ b/tools/RestoreNativeLibraries/RestoreNativeLibraries.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- This bootstrap tool has no NuGet dependencies. Avoid network-bound audit probes before it can restore runtimes. -->
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Add a cross-platform `RestoreNativeLibraries` tool for downloading and installing preview native runtimes.
- Cache runtimes by pinned `whisper.cpp` revision, with locking, atomic publication, validation, retries, and cache controls.
- Automatically validate native runtimes before managed tests build.
- Update contributor and development documentation and ignore shared `.whisper` caches.
- Include the restore tool in the solution.
