### PR TITLE
Fix AsyncAutoResetEvent synchronization and CI test failures

### DIFF
--- a/Whisper.net/Internals/AsyncAutoResetEvent.cs
+++ b/Whisper.net/Internals/AsyncAutoResetEvent.cs
@@ -5,34 +5,39 @@ namespace Whisper.net.Internals;
 internal class AsyncAutoResetEvent
 {
     private static readonly Task Completed = Task.CompletedTask;
-    private TaskCompletionSource<bool>? waitTcs;
-    private int isSignaled; // 0 for false, 1 for true
+    private readonly object sync = new();
+    private readonly Queue<TaskCompletionSource<bool>> waiters = new();
+    private bool isSignaled;
 
     public Task WaitAsync()
     {
-        if (Interlocked.CompareExchange(ref isSignaled, 0, 1) == 1)
+        lock (sync)
         {
-            return Completed;
-        }
-        else
-        {
-            var tcs = new TaskCompletionSource<bool>();
-            var oldTcs = Interlocked.Exchange(ref waitTcs, tcs);
-            oldTcs?.TrySetCanceled();
-            return tcs.Task;
+            if (isSignaled)
+            {
+                isSignaled = false;
+                return Completed;
+            }
+
+            var waiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            waiters.Enqueue(waiter);
+            return waiter.Task;
         }
     }
 
     public void Set()
     {
-        var toRelease = Interlocked.Exchange(ref waitTcs, null);
-        if (toRelease != null)
+        TaskCompletionSource<bool>? toRelease;
+        lock (sync)
         {
-            toRelease.SetResult(true);
+            toRelease = waiters.Count > 0 ? waiters.Dequeue() : null;
+
+            if (toRelease == null)
+            {
+                isSignaled = true;
+            }
         }
-        else
-        {
-            Interlocked.Exchange(ref isSignaled, 1);
-        }
+
+        toRelease?.SetResult(true);
     }
 }

--- a/Whisper.net/Internals/AsyncAutoResetEvent.cs
+++ b/Whisper.net/Internals/AsyncAutoResetEvent.cs
@@ -5,7 +5,11 @@ namespace Whisper.net.Internals;
 internal class AsyncAutoResetEvent
 {
     private static readonly Task Completed = Task.CompletedTask;
+#if NET9_0_OR_GREATER
+    private readonly Lock sync = new();
+#else
     private readonly object sync = new();
+#endif
     private readonly Queue<TaskCompletionSource<bool>> waiters = new();
     private bool isSignaled;
 

--- a/tests/Whisper.net.Tests/AsyncAutoResetEventTests.cs
+++ b/tests/Whisper.net.Tests/AsyncAutoResetEventTests.cs
@@ -1,0 +1,47 @@
+// Licensed under the MIT license: https://opensource.org/licenses/MIT
+
+using Whisper.net.Internals;
+using Xunit;
+
+namespace Whisper.net.Tests;
+
+public class AsyncAutoResetEventTests
+{
+    [Fact]
+    public async Task Set_BeforeWait_CompletesOneWait()
+    {
+        var resetEvent = new AsyncAutoResetEvent();
+
+        resetEvent.Set();
+
+        await resetEvent.WaitAsync();
+        Assert.False(resetEvent.WaitAsync().IsCompleted);
+    }
+
+    [Fact]
+    public async Task Set_AfterWait_CompletesWait()
+    {
+        var resetEvent = new AsyncAutoResetEvent();
+        var waitTask = resetEvent.WaitAsync();
+
+        resetEvent.Set();
+
+        await waitTask;
+    }
+
+    [Fact]
+    public async Task Set_WithMultipleWaiters_CompletesOneWaitAtATime()
+    {
+        var resetEvent = new AsyncAutoResetEvent();
+        var firstWaitTask = resetEvent.WaitAsync();
+        var secondWaitTask = resetEvent.WaitAsync();
+
+        resetEvent.Set();
+
+        await firstWaitTask;
+        Assert.False(secondWaitTask.IsCompleted);
+
+        resetEvent.Set();
+        await secondWaitTask;
+    }
+}


### PR DESCRIPTION
## Summary

- Rework `AsyncAutoResetEvent` synchronization for reliable waiter management.
- Preserve target-specific locking with `Lock` on .NET 9+ and `object` elsewhere.
- Ensure waiters complete asynchronously and are released one at a time.
- Add coverage for signaling before waiting, signaling after waiting, and multiple waiters.

## Testing

- Added unit tests covering auto-reset event signaling and waiter ordering.